### PR TITLE
Added processing for stronger joints

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -115,6 +115,8 @@ namespace MatterHackers.MatterSlice
         public double infillTotalProportion;
         [SettingDescription("If the solid infill area is less than this proportion of the total infill area make it all solid. Helps with bolt or screw head torque problems.")]
         public double infillSolidProportion;
+        [SettingDescription("If the infill area (not solid infill) is smaller than this amount make it solid.")]
+	    public double minInfillArea_mm2;
 
 		[SettingDescription("The percent of filled space to open space while infilling.")]
 		public double infillPercent;
@@ -351,6 +353,7 @@ namespace MatterHackers.MatterSlice
             infillSolidProportion = 0.0;
             infillTotalProportion = 0.0;
 		    smallProtrusionProportion = 0.0;
+		    minInfillArea_mm2 = 0.0;
 
 			firstLayerSpeed = 20;
 			supportMaterialSpeed = 40;

--- a/Settings.cs
+++ b/Settings.cs
@@ -111,8 +111,6 @@ namespace MatterHackers.MatterSlice
 
         [SettingDescription("If this layer is much smaller than the ones below or above it make it solid. Helps with bolt or screw head torque problems.")]
         public double smallProtrusionProportion;
-        [SettingDescription("If the infill and solid infill areas combined are smaller than this proportion of the solid top make it all solid top. Helps with bolt or screw head torque problems.")]
-        public double infillTotalProportion;
         [SettingDescription("If the solid infill area is less than this proportion of the total infill area make it all solid. Helps with bolt or screw head torque problems.")]
         public double infillSolidProportion;
         [SettingDescription("If the infill area (not solid infill) is smaller than this amount make it solid.")]
@@ -351,7 +349,6 @@ namespace MatterHackers.MatterSlice
 			numberOfTopLayers = 6;
 
             infillSolidProportion = 0.0;
-            infillTotalProportion = 0.0;
 		    smallProtrusionProportion = 0.0;
 		    minInfillArea_mm2 = 0.0;
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -109,6 +109,13 @@ namespace MatterHackers.MatterSlice
 		public int numberOfBottomLayers;
 		public int numberOfTopLayers;
 
+        [SettingDescription("If this layer is much smaller than the ones below or above it make it solid. Helps with bolt or screw head torque problems.")]
+        public double smallProtrusionProportion;
+        [SettingDescription("If the infill and solid infill areas combined are smaller than this proportion of the solid top make it all solid top. Helps with bolt or screw head torque problems.")]
+        public double infillTotalProportion;
+        [SettingDescription("If the solid infill area is less than this proportion of the total infill area make it all solid. Helps with bolt or screw head torque problems.")]
+        public double infillSolidProportion;
+
 		[SettingDescription("The percent of filled space to open space while infilling.")]
 		public double infillPercent;
 
@@ -340,6 +347,11 @@ namespace MatterHackers.MatterSlice
 			numberOfPerimeters = 2;
 			numberOfBottomLayers = 6;
 			numberOfTopLayers = 6;
+
+            infillSolidProportion = 0.0;
+            infillTotalProportion = 0.0;
+		    smallProtrusionProportion = 0.0;
+
 			firstLayerSpeed = 20;
 			supportMaterialSpeed = 40;
 			infillSpeed = 50;

--- a/Tests/MatterSlice.Tests/MatterSlice/CreateTopAndBottomsTests.cs
+++ b/Tests/MatterSlice.Tests/MatterSlice/CreateTopAndBottomsTests.cs
@@ -130,9 +130,10 @@ namespace MatterHackers.MatterSlice.Tests
 		private static void GenerateLayers(SliceVolumeStorage layerData, int extrusionWidth, int bottomLayers, int topLayers)
 		{
 			int numLayers = layerData.layers.Count;
+		    ConfigSettings config = new ConfigSettings {numberOfBottomLayers = bottomLayers, numberOfTopLayers = topLayers};
 			for (int i = 0; i < numLayers; i++)
 			{
-				TopsAndBottoms.GenerateTopAndBottom(i, layerData, extrusionWidth, bottomLayers, topLayers);
+				TopsAndBottoms.GenerateTopAndBottom(i, layerData, extrusionWidth, config);
 			}
 		}
 

--- a/TopsAndBottoms.cs
+++ b/TopsAndBottoms.cs
@@ -135,7 +135,7 @@ namespace MatterHackers.MatterSlice
                     Polygons totalInfillOutlines = null;
                     double totalInfillArea = 0.0;
 
-                    if (config.infillSolidProportion > 0 || config.infillTotalProportion > 0)
+                    if (config.infillSolidProportion > 0)
                     {
                         totalInfillOutlines = infillOutlines.CreateUnion(solidInfillOutlines);
                         totalInfillArea = totalInfillOutlines.TotalArea();
@@ -150,11 +150,8 @@ namespace MatterHackers.MatterSlice
                             infillOutlines = new Polygons();
                             part.SolidInfillOutlines = solidInfillOutlines;
                         }
-                    }
-                    if (config.infillTotalProportion > 0)
-                    {
                         var solidTopOutlinesArea = part.SolidTopOutlines.TotalArea();
-                        if (totalInfillArea < solidTopOutlinesArea * config.infillTotalProportion)
+                        if (totalInfillArea < solidTopOutlinesArea * config.infillSolidProportion / 2)
                         {
                             var totalSolidTop = totalInfillOutlines.CreateUnion(part.SolidTopOutlines);
                             part.SolidTopOutlines = totalSolidTop;

--- a/TopsAndBottoms.cs
+++ b/TopsAndBottoms.cs
@@ -162,6 +162,16 @@ namespace MatterHackers.MatterSlice
                             infillOutlines = part.InfillOutlines = new Polygons();
                         }
                     }
+                    if (config.minInfillArea_mm2 > 0)
+                    {
+                        var infillArea = infillOutlines.TotalArea()/1e6; // convert from um2 to mm2
+                        if (infillArea < config.minInfillArea_mm2)
+                        {
+                            solidInfillOutlines = solidInfillOutlines.CreateUnion(infillOutlines);
+                            infillOutlines = new Polygons();
+                            part.SolidInfillOutlines = solidInfillOutlines;
+                        }
+                    }
                 }
 
                 RemoveSmallAreas(extrusionWidth, infillOutlines);

--- a/TopsAndBottoms.cs
+++ b/TopsAndBottoms.cs
@@ -1,4 +1,4 @@
-/*
+/* 
 This file is part of MatterSlice. A commandline utility for
 generating 3D printing GCode.
 
@@ -19,162 +19,227 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using MatterSlice.ClipperLib;
 using System;
 using System.Collections.Generic;
+using MatterSlice.ClipperLib;
 
 namespace MatterHackers.MatterSlice
 {
-	using Polygons = List<List<IntPoint>>;
+    using Polygons = List<List<IntPoint>>;
 
-	public static class TopsAndBottoms
-	{
-		readonly static double cleanDistance_um = 10;
+    public static class TopsAndBottoms
+    {
+        private static readonly double cleanDistance_um = 10;
 
-		public static void GenerateTopAndBottom(int layerIndex, SliceVolumeStorage storage, int extrusionWidth, int downLayerCount, int upLayerCount)
-		{
-			SliceLayer layer = storage.layers[layerIndex];
+        public static void GenerateTopAndBottom(int layerIndex, SliceVolumeStorage storage, int extrusionWidth, ConfigSettings config)
+        {
+            var downLayerCount = config.numberOfBottomLayers;
+            var upLayerCount = config.numberOfTopLayers;
 
-			for (int partIndex = 0; partIndex < layer.parts.Count; partIndex++)
-			{
-				SliceLayerPart part = layer.parts[partIndex];
-				Polygons insetWithOffset = part.Insets[part.Insets.Count - 1].Offset(-extrusionWidth / 2);
-				Polygons infillOutlines = new Polygons(insetWithOffset);
+            var layer = storage.layers[layerIndex];
+            for (var partIndex = 0; partIndex < layer.parts.Count; partIndex++)
+            {
+                var part = layer.parts[partIndex];
+                var insetWithOffset = part.Insets[part.Insets.Count - 1].Offset(-extrusionWidth / 2);
+                var infillOutlines = new Polygons(insetWithOffset);
 
-				// calculate the bottom outlines
-				if (downLayerCount > 0)
-				{
-					Polygons bottomOutlines = new Polygons(insetWithOffset);
+                // calculate the bottom outlines
+                if (downLayerCount > 0)
+                {
+                    var bottomOutlines = new Polygons(insetWithOffset);
 
-					if (layerIndex - 1 >= 0)
-					{
-						bottomOutlines = RemoveAdditionalOutlinesForPart(storage.layers[layerIndex - 1], part, bottomOutlines);
-						RemoveSmallAreas(extrusionWidth, bottomOutlines);
-					}
+                    if (layerIndex - 1 >= 0)
+                    {
+                        bottomOutlines = RemoveAdditionalOutlinesForPart(storage.layers[layerIndex - 1], part, bottomOutlines);
+                        RemoveSmallAreas(extrusionWidth, bottomOutlines);
+                    }
 
-					infillOutlines = infillOutlines.CreateDifference(bottomOutlines);
-					infillOutlines = Clipper.CleanPolygons(infillOutlines, cleanDistance_um);
+                    infillOutlines = infillOutlines.CreateDifference(bottomOutlines);
+                    infillOutlines = Clipper.CleanPolygons(infillOutlines, cleanDistance_um);
 
-					part.SolidBottomOutlines = bottomOutlines;
-				}
+                    part.SolidBottomOutlines = bottomOutlines;
+                }
 
-				// calculate the top outlines
-				if(upLayerCount > 0)
-				{
-					Polygons topOutlines = new Polygons(insetWithOffset);
-					topOutlines = topOutlines.CreateDifference(part.SolidBottomOutlines);
-					topOutlines = Clipper.CleanPolygons(topOutlines, cleanDistance_um);
+                // calculate the top outlines
+                if (upLayerCount > 0)
+                {
+                    var topOutlines = new Polygons(insetWithOffset);
+                    topOutlines = topOutlines.CreateDifference(part.SolidBottomOutlines);
+                    topOutlines = Clipper.CleanPolygons(topOutlines, cleanDistance_um);
 
-					if (part.Insets.Count > 1)
-					{
-						// Add thin wall filling by taking the area between the insets.
-						Polygons thinWalls = part.Insets[0].Offset(-extrusionWidth / 2).CreateDifference(part.Insets[1].Offset(extrusionWidth / 2));
-						topOutlines.AddAll(thinWalls);
-					}
+                    if (part.Insets.Count > 1)
+                    {
+                        // Add thin wall filling by taking the area between the insets.
+                        var thinWalls =
+                            part.Insets[0].Offset(-extrusionWidth / 2)
+                                          .CreateDifference(part.Insets[1].Offset(extrusionWidth / 2));
+                        topOutlines.AddAll(thinWalls);
+                    }
 
-					if (layerIndex + 1 < storage.layers.Count)
-					{
-						topOutlines = RemoveAdditionalOutlinesForPart(storage.layers[layerIndex + 1], part, topOutlines);
-						RemoveSmallAreas(extrusionWidth, topOutlines);
-					}
+                    if (layerIndex + 1 < storage.layers.Count)
+                    {
+                        topOutlines = RemoveAdditionalOutlinesForPart(storage.layers[layerIndex + 1], part, topOutlines);
+                        RemoveSmallAreas(extrusionWidth, topOutlines);
+                    }
 
-					infillOutlines = infillOutlines.CreateDifference(topOutlines);
-					infillOutlines = Clipper.CleanPolygons(infillOutlines, cleanDistance_um);
+                    infillOutlines = infillOutlines.CreateDifference(topOutlines);
+                    infillOutlines = Clipper.CleanPolygons(infillOutlines, cleanDistance_um);
 
-					part.SolidTopOutlines = topOutlines;
-				}
+                    part.SolidTopOutlines = topOutlines;
+                }
 
-				// calculate the solid infill outlines
-				if (upLayerCount > 1 || downLayerCount > 1)
-				{
-					Polygons solidInfillOutlines = new Polygons(insetWithOffset);
-					solidInfillOutlines = solidInfillOutlines.CreateDifference(part.SolidBottomOutlines);
-					solidInfillOutlines = Clipper.CleanPolygons(solidInfillOutlines, cleanDistance_um);
-					solidInfillOutlines = solidInfillOutlines.CreateDifference(part.SolidTopOutlines);
-					solidInfillOutlines = Clipper.CleanPolygons(solidInfillOutlines, cleanDistance_um);
+                // calculate the solid infill outlines
+                if (upLayerCount > 1 || downLayerCount > 1)
+                {
+                    var solidInfillOutlines = new Polygons(insetWithOffset);
+                    solidInfillOutlines = solidInfillOutlines.CreateDifference(part.SolidBottomOutlines);
+                    solidInfillOutlines = Clipper.CleanPolygons(solidInfillOutlines, cleanDistance_um);
+                    solidInfillOutlines = solidInfillOutlines.CreateDifference(part.SolidTopOutlines);
+                    solidInfillOutlines = Clipper.CleanPolygons(solidInfillOutlines, cleanDistance_um);
 
-					int upEnd = layerIndex + upLayerCount + 1;
-					if (upEnd <= storage.layers.Count && layerIndex - downLayerCount >= 0)
-					{
-						Polygons totalPartsToRemove = new Polygons(insetWithOffset);
+                    var upStart = layerIndex + 2;
+                    var upEnd = layerIndex + upLayerCount + 1;
+                    var downStart = layerIndex - 1;
+                    var downEnd = layerIndex - downLayerCount;
 
-						int upStart = layerIndex + 2;
+                    if (upEnd <= storage.layers.Count && downEnd >= 0)
+                    {
+                        var makeInfillSolid = false;
+                        var totalPartsToRemove = new Polygons(insetWithOffset);
 
-						for (int layerToTest = upStart; layerToTest < upEnd; layerToTest++)
-						{
-							totalPartsToRemove = AddAllOutlines(storage.layers[layerToTest], part, totalPartsToRemove);
-							totalPartsToRemove = Clipper.CleanPolygons(totalPartsToRemove, cleanDistance_um);
-						}
+                        for (var layerToTest = upStart; layerToTest < upEnd; layerToTest++)
+                        {
+                            totalPartsToRemove = AddAllOutlines(storage.layers[layerToTest], part, totalPartsToRemove, out makeInfillSolid, config);
+                            totalPartsToRemove = Clipper.CleanPolygons(totalPartsToRemove, cleanDistance_um);
+                            if (makeInfillSolid) break;
+                        }
 
-						int downStart = layerIndex - 1;
-						int downEnd = layerIndex - downLayerCount;
+                        for (var layerToTest = downStart; layerToTest >= downEnd; layerToTest--)
+                        {
+                            totalPartsToRemove = AddAllOutlines(storage.layers[layerToTest], part, totalPartsToRemove, out makeInfillSolid, config);
+                            totalPartsToRemove = Clipper.CleanPolygons(totalPartsToRemove, cleanDistance_um);
+                            if (makeInfillSolid) break;
+                        }
 
-						for (int layerToTest = downStart; layerToTest >= downEnd; layerToTest--)
-						{
-							totalPartsToRemove = AddAllOutlines(storage.layers[layerToTest], part, totalPartsToRemove);
-							totalPartsToRemove = Clipper.CleanPolygons(totalPartsToRemove, cleanDistance_um);
-						}
+                        if (!makeInfillSolid)
+                        {
+                            solidInfillOutlines = solidInfillOutlines.CreateDifference(totalPartsToRemove);
+                            RemoveSmallAreas(extrusionWidth, solidInfillOutlines);
+                        }
 
-						solidInfillOutlines = solidInfillOutlines.CreateDifference(totalPartsToRemove);
-						RemoveSmallAreas(extrusionWidth, solidInfillOutlines);
+                        solidInfillOutlines = Clipper.CleanPolygons(solidInfillOutlines, cleanDistance_um);
+                    }
 
-						solidInfillOutlines = Clipper.CleanPolygons(solidInfillOutlines, cleanDistance_um);
-					}
+                    part.SolidInfillOutlines = solidInfillOutlines;
+                    infillOutlines = infillOutlines.CreateDifference(solidInfillOutlines);
 
-					part.SolidInfillOutlines = solidInfillOutlines;
-					infillOutlines = infillOutlines.CreateDifference(solidInfillOutlines);
-				}
+                    Polygons totalInfillOutlines = null;
+                    double totalInfillArea = 0.0;
 
-				RemoveSmallAreas(extrusionWidth, infillOutlines);
-				infillOutlines = Clipper.CleanPolygons(infillOutlines, cleanDistance_um);
-				part.InfillOutlines = infillOutlines;
-			}
-		}
+                    if (config.infillSolidProportion > 0 || config.infillTotalProportion > 0)
+                    {
+                        totalInfillOutlines = infillOutlines.CreateUnion(solidInfillOutlines);
+                        totalInfillArea = totalInfillOutlines.TotalArea();
+                    }
 
-		private static void RemoveSmallAreas(int extrusionWidth, Polygons solidInfillOutlinesUp)
-		{
-			double minAreaSize = (2 * Math.PI * (extrusionWidth / 1000.0) * (extrusionWidth / 1000.0)) * 0.3;
-			for (int outlineIndex = 0; outlineIndex < solidInfillOutlinesUp.Count; outlineIndex++)
-			{
-				double area = Math.Abs(solidInfillOutlinesUp[outlineIndex].Area()) / 1000.0 / 1000.0;
-				if (area < minAreaSize) // Only create an up/down Outline if the area is large enough. So you do not create tiny blobs of "trying to fill"
-				{
-					solidInfillOutlinesUp.RemoveAt(outlineIndex);
-					outlineIndex -= 1;
-				}
-			}
-		}
+                    if (config.infillSolidProportion > 0)
+                    {
+                        var solidInfillArea = solidInfillOutlines.TotalArea();
+                        if (solidInfillArea > totalInfillArea * config.infillSolidProportion)
+                        {
+                            solidInfillOutlines = solidInfillOutlines.CreateUnion(infillOutlines);
+                            infillOutlines = new Polygons();
+                            part.SolidInfillOutlines = solidInfillOutlines;
+                        }
+                    }
+                    if (config.infillTotalProportion > 0)
+                    {
+                        var solidTopOutlinesArea = part.SolidTopOutlines.TotalArea();
+                        if (totalInfillArea < solidTopOutlinesArea * config.infillTotalProportion)
+                        {
+                            var totalSolidTop = totalInfillOutlines.CreateUnion(part.SolidTopOutlines);
+                            part.SolidTopOutlines = totalSolidTop;
+                            part.SolidInfillOutlines = new Polygons();
+                            infillOutlines = part.InfillOutlines = new Polygons();
+                        }
+                    }
+                }
 
-		private static Polygons RemoveAdditionalOutlinesForPart(SliceLayer layerToSubtract, SliceLayerPart partToUseAsBounds, Polygons polygonsToSubtractFrom)
-		{
-			for (int partIndex = 0; partIndex < layerToSubtract.parts.Count; partIndex++)
-			{
-				if (partToUseAsBounds.BoundingBox.Hit(layerToSubtract.parts[partIndex].BoundingBox))
-				{
-					polygonsToSubtractFrom = polygonsToSubtractFrom.CreateDifference(layerToSubtract.parts[partIndex].Insets[layerToSubtract.parts[partIndex].Insets.Count - 1]);
+                RemoveSmallAreas(extrusionWidth, infillOutlines);
+                infillOutlines = Clipper.CleanPolygons(infillOutlines, cleanDistance_um);
+                part.InfillOutlines = infillOutlines;
+            }
+        }
 
-					polygonsToSubtractFrom = Clipper.CleanPolygons(polygonsToSubtractFrom, cleanDistance_um);
-				}
-			}
+        private static void RemoveSmallAreas(int extrusionWidth, Polygons solidInfillOutlinesUp)
+        {
+            var minAreaSize = (2 * Math.PI * (extrusionWidth / 1000.0) * (extrusionWidth / 1000.0)) * 0.3;
+            for (var outlineIndex = 0; outlineIndex < solidInfillOutlinesUp.Count; outlineIndex++)
+            {
+                var area = Math.Abs(solidInfillOutlinesUp[outlineIndex].Area()) / 1000.0 / 1000.0;
+                if (area < minAreaSize)
+                // Only create an up/down Outline if the area is large enough. So you do not create tiny blobs of "trying to fill"
+                {
+                    solidInfillOutlinesUp.RemoveAt(outlineIndex);
+                    outlineIndex -= 1;
+                }
+            }
+        }
 
-			return polygonsToSubtractFrom;
-		}
+        private static Polygons RemoveAdditionalOutlinesForPart(SliceLayer layerToSubtract, SliceLayerPart partToUseAsBounds,
+                                                                Polygons polygonsToSubtractFrom)
+        {
+            for (var partIndex = 0; partIndex < layerToSubtract.parts.Count; partIndex++)
+            {
+                if (partToUseAsBounds.BoundingBox.Hit(layerToSubtract.parts[partIndex].BoundingBox))
+                {
+                    polygonsToSubtractFrom =
+                        polygonsToSubtractFrom.CreateDifference(
+                            layerToSubtract.parts[partIndex].Insets[layerToSubtract.parts[partIndex].Insets.Count - 1]);
 
-		private static Polygons AddAllOutlines(SliceLayer layerToAdd, SliceLayerPart partToUseAsBounds, Polygons polysToAddTo)
-		{
-			Polygons polysToIntersect = new Polygons();
-			for (int partIndex = 0; partIndex < layerToAdd.parts.Count; partIndex++)
-			{
-				if (partToUseAsBounds.BoundingBox.Hit(layerToAdd.parts[partIndex].BoundingBox))
-				{
-					polysToIntersect = polysToIntersect.CreateUnion(layerToAdd.parts[partIndex].Insets[layerToAdd.parts[partIndex].Insets.Count - 1]);
-					polysToIntersect = Clipper.CleanPolygons(polysToIntersect, cleanDistance_um);
-				}
-			}
+                    polygonsToSubtractFrom = Clipper.CleanPolygons(polygonsToSubtractFrom, cleanDistance_um);
+                }
+            }
 
-			polysToAddTo = polysToAddTo.CreateIntersection(polysToIntersect);
+            return polygonsToSubtractFrom;
+        }
 
-			return polysToAddTo;
-		}
-	}
+        private static Polygons AddAllOutlines(SliceLayer layerToAdd, SliceLayerPart partToUseAsBounds, Polygons polysToAddTo, out bool makeInfillSolid, ConfigSettings config)
+        {
+            makeInfillSolid = false;
+
+            var polysToIntersect = new Polygons();
+            for (var partIndex = 0; partIndex < layerToAdd.parts.Count; partIndex++)
+            {
+                var partToConsider = layerToAdd.parts[partIndex];
+
+                if (config.smallProtrusionProportion > 0)
+                {
+                    // If the part under consideration intersects the part from the current layer and 
+                    // the area of that intersection is less than smallProtrusionProportion % of the part under consideration solidify the infill
+                    var intersection = partToUseAsBounds.TotalOutline.CreateIntersection(partToConsider.TotalOutline);
+                    if (intersection.Count > 0) // They do intersect
+                    {
+                        if (intersection.TotalArea() < partToConsider.TotalOutline.TotalArea() * config.smallProtrusionProportion)
+                        {
+                            makeInfillSolid = true;
+                            return polysToAddTo;
+                        }
+                    }
+                }
+
+                if (partToUseAsBounds.BoundingBox.Hit(partToConsider.BoundingBox))
+                {
+                    polysToIntersect =
+                        polysToIntersect.CreateUnion(
+                            layerToAdd.parts[partIndex].Insets[partToConsider.Insets.Count - 1]);
+                    polysToIntersect = Clipper.CleanPolygons(polysToIntersect, cleanDistance_um);
+                }
+            }
+
+            polysToAddTo = polysToAddTo.CreateIntersection(polysToIntersect);
+
+            return polysToAddTo;
+        }
+    }
 }

--- a/fffProcessor.cs
+++ b/fffProcessor.cs
@@ -285,12 +285,12 @@ namespace MatterHackers.MatterSlice
 							extrusionWidth = config.firstLayerExtrusionWidth_um;
 						}
 
-						TopsAndBottoms.GenerateTopAndBottom(layerIndex, storage.volumes[volumeIndex], extrusionWidth, config.numberOfBottomLayers, config.numberOfTopLayers);
+						TopsAndBottoms.GenerateTopAndBottom(layerIndex, storage.volumes[volumeIndex], extrusionWidth, config);
 					}
 				}
 				LogOutput.Log("Creating Top & Bottom Layers {0}/{1}\n".FormatWith(layerIndex + 1, totalLayers));
 			}
-			LogOutput.Log("Generated top bottom layers in {0:0.0}s\n".FormatWith(timeKeeper.Elapsed.Seconds));
+			LogOutput.Log("Generated top bottom layers in {0:0.000}s\n".FormatWith(timeKeeper.Elapsed.Milliseconds/1000));
 			timeKeeper.Restart();
 
 			if (config.wipeTowerSize_um > 0)
@@ -541,7 +541,7 @@ namespace MatterHackers.MatterSlice
 
 			LogOutput.Log("Wrote layers in {0:0.00}s.\n".FormatWith(timeKeeper.Elapsed.Seconds));
 			timeKeeper.Restart();
-			gcode.TellFileSize();
+//			gcode.TellFileSize();
 			gcode.WriteFanCommand(0);
 
 			//Store the object height for when we are printing multiple objects, as we need to clear every one of them when moving to the next position.
@@ -750,17 +750,10 @@ namespace MatterHackers.MatterSlice
 			// generate infill intermediate layers
 			foreach (Polygons outline in part.SolidInfillOutlines.CreateLayerOutlines(PolygonsHelper.LayerOpperation.EvenOdd))
 			{
-				if (true) // use the old infill method
-				{
-					Infill.GenerateLinePaths(outline, ref fillPolygons, config.extrusionWidth_um, config.infillExtendIntoPerimeter_um, config.infillStartingAngle + 90 * (layerIndex % 2));
-				}
-				else // use the new concentric infill (not tested enough yet) have to handle some bad casses better
-				{
-					double oldInfillPercent = config.infillPercent;
-					config.infillPercent = 100;
-					Infill.GenerateConcentricInfill(config, outline, ref fillPolygons);
-					config.infillPercent = oldInfillPercent;
-				}
+				double oldInfillPercent = config.infillPercent;
+				config.infillPercent = 100;
+				Infill.GenerateConcentricInfill(config, outline, ref fillPolygons);
+				config.infillPercent = oldInfillPercent;
 			}
 
 			double fillAngle = config.infillStartingAngle;

--- a/utils/PolygonHelper.cs
+++ b/utils/PolygonHelper.cs
@@ -19,6 +19,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System.Linq;
 using MatterSlice.ClipperLib;
 using System;
 using System.Collections.Generic;
@@ -105,7 +106,7 @@ namespace MatterHackers.MatterSlice
 			return true;
 		}
 
-		public static Polygon CreateFromString(string polygonString)
+	    public static Polygon CreateFromString(string polygonString)
 		{
 			Polygon output = new Polygon();
 			string[] intPointData = polygonString.Split(',');
@@ -505,5 +506,10 @@ namespace MatterHackers.MatterSlice
 				ret.Add(polygons);
 			}
 		}
+
+        public static double TotalArea(this Polygons polygons)
+        {
+            return polygons.Sum(polygon => polygon.Area());
+        }
 	}
 }


### PR DESCRIPTION
Hey guys,

I added additional TopsAndBottoms processing: If a part gets suddenly smaller or larger (think bolt head and then shaft) it tends to handle torque poorly (head comes off bolt) because of the infill space. This removes infill space from the top layers immediately below such a junction and the layers immediately above based on new ConfigSettings. It leaves the infill elsewhere so rather than needing to up the infill percentage for the whole thing this increases the solidity around the junction.

If you would be interested in including this let me know and I'll do a proper write up of it including an example ... short version is it helps small parts attached to larger parts not break off as easily.

Cheers,

Gareth.