### PR TITLE
Apply bridge fan speed to bridged region

### DIFF
--- a/ConfigSettings.cs
+++ b/ConfigSettings.cs
@@ -23,6 +23,7 @@ using ClipperLib;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace MatterHackers.MatterSlice
@@ -57,6 +58,9 @@ namespace MatterHackers.MatterSlice
 	// all the variables in this class will be saved and loaded from settings files
 	public class ConfigSettings
 	{
+		// Store all public property instance properties in a local static variable
+		private static List<PropertyInfo> allProperties = typeof(ConfigSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance).ToList();
+
 		public ConfigSettings()
 		{
 			SetToDefault();
@@ -461,13 +465,14 @@ namespace MatterHackers.MatterSlice
 		{
 			valueToSetTo = valueToSetTo.Replace("\"", "").Trim();
 
-			List<string> lines = new List<string>();
-			foreach (PropertyInfo property in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+			foreach (PropertyInfo property in allProperties)
 			{
 				// List of case insensitive names that will import as this property
 				HashSet<string> possibleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 				possibleNames.Add(property.Name);
 
+				// TODO: No one makes use of the LegacyName attribute thus the possibleNames HashSet and the LegacyName class could be removed as part of a code cleanup pass
+				//
 				// Including any mapped LegacyName attributes
 				foreach (Attribute attribute in Attribute.GetCustomAttributes(property))
 				{

--- a/ConfigSettings.cs
+++ b/ConfigSettings.cs
@@ -58,7 +58,7 @@ namespace MatterHackers.MatterSlice
 	// all the variables in this class will be saved and loaded from settings files
 	public class ConfigSettings
 	{
-		// Store all public property instance properties in a local static variable
+		// Store all public instance properties in a local static list to resolve settings mappings
 		private static List<PropertyInfo> allProperties = typeof(ConfigSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance).ToList();
 
 		public ConfigSettings()

--- a/GCodePathConfig.cs
+++ b/GCodePathConfig.cs
@@ -45,13 +45,6 @@ namespace MatterHackers.MatterSlice
 		{
 		}
 
-		public GCodePathConfig(double speed, int lineWidth_um, string name)
-		{
-			this.speed = speed;
-			this.lineWidth_um = lineWidth_um;
-			this.gcodeComment = name;
-		}
-
 		/// <summary>
 		/// Set the data for a path config. This is used to define how different parts (infill, perimeters) are written to gcode.
 		/// </summary>

--- a/GCodePathConfig.cs
+++ b/GCodePathConfig.cs
@@ -31,18 +31,22 @@ namespace MatterHackers.MatterSlice
 
 	using Polygons = List<List<IntPoint>>;
 
-	//The GCodePathConfig is the configuration for moves/extrusion actions. This defines at which width the line is printed and at which speed.
+	/// <summary>
+	/// Contains the configuration for moves/extrusion actions. This defines at which width the line is printed and at which speed.
+	/// </summary>
 	public class GCodePathConfig
 	{
 		public bool closedLoop = true;
 		public int lineWidth_um;
 		public string gcodeComment;
 		public double speed;
+		private string Name { get; set; }
 		public bool spiralize;
 		public bool doSeamHiding;
 
-		public GCodePathConfig()
+		public GCodePathConfig(string configName)
 		{
+			this.Name = configName;
 		}
 
 		/// <summary>

--- a/GCodePlanner.cs
+++ b/GCodePlanner.cs
@@ -61,14 +61,14 @@ namespace MatterHackers.MatterSlice
 
 		private double totalPrintTime;
 
-		private GCodePathConfig travelConfig = new GCodePathConfig();
+		private GCodePathConfig travelConfig;
 
 		private int travelSpeedFactor;
 
 		public GCodePlanner(GCodeExport gcode, int travelSpeed, int retractionMinimumDistance_um)
 		{
 			this.gcodeExport = gcode;
-			travelConfig = new GCodePathConfig();
+			travelConfig =  new GCodePathConfig("travelConfig");
 			travelConfig.SetData(travelSpeed, 0, "travel");
 
 			LastPosition = gcode.GetPositionXY();

--- a/GCodePlanner.cs
+++ b/GCodePlanner.cs
@@ -345,7 +345,7 @@ namespace MatterHackers.MatterSlice
 			LastPosition = destination;
 		}
 
-		public void WriteQueuedGCode(int layerThickness)
+		public void WriteQueuedGCode(int layerThickness, int fanSpeedPercent = -1, int bridgeFanSpeedPercent = -1)
 		{
 			GCodePathConfig lastConfig = null;
 			int extruderIndex = gcodeExport.GetExtruderIndex();
@@ -364,6 +364,15 @@ namespace MatterHackers.MatterSlice
 				}
 				if (path.config != travelConfig && lastConfig != path.config)
 				{
+					if (path.config.gcodeComment == "BRIDGE" && bridgeFanSpeedPercent != -1)
+					{
+						gcodeExport.WriteFanCommand(bridgeFanSpeedPercent);	
+					}
+					else if (lastConfig?.gcodeComment == "BRIDGE" && bridgeFanSpeedPercent != -1)
+					{
+						gcodeExport.WriteFanCommand(fanSpeedPercent);
+					}
+
 					gcodeExport.WriteComment("TYPE:{0}".FormatWith(path.config.gcodeComment));
 					lastConfig = path.config;
 				}

--- a/GCodePlanner.cs
+++ b/GCodePlanner.cs
@@ -68,7 +68,8 @@ namespace MatterHackers.MatterSlice
 		public GCodePlanner(GCodeExport gcode, int travelSpeed, int retractionMinimumDistance_um)
 		{
 			this.gcodeExport = gcode;
-			travelConfig = new GCodePathConfig(travelSpeed, 0, "travel");
+			travelConfig = new GCodePathConfig();
+			travelConfig.SetData(travelSpeed, 0, "travel");
 
 			LastPosition = gcode.GetPositionXY();
 			outerPerimetersToAvoidCrossing = null;

--- a/LayerDataStorage.cs
+++ b/LayerDataStorage.cs
@@ -224,13 +224,13 @@ namespace MatterHackers.MatterSlice
 			LayerDataStorage storage = this;
 			if (config.ShouldGenerateRaft())
 			{
-				GCodePathConfig raftBaseConfig = new GCodePathConfig();
+				GCodePathConfig raftBaseConfig = new GCodePathConfig("raftBaseConfig");
 				raftBaseConfig.SetData(config.FirstLayerSpeed, config.RaftBaseExtrusionWidth_um, "SUPPORT");
 
-				GCodePathConfig raftMiddleConfig = new GCodePathConfig();
+				GCodePathConfig raftMiddleConfig = new GCodePathConfig("raftMiddleConfig");
 				raftMiddleConfig.SetData(config.RaftPrintSpeed, config.RaftInterfaceExtrusionWidth_um, "SUPPORT");
 
-				GCodePathConfig raftSurfaceConfig = new GCodePathConfig();
+				GCodePathConfig raftSurfaceConfig = new GCodePathConfig("raftMiddleConfig");
 				raftSurfaceConfig.SetData((config.RaftSurfacePrintSpeed > 0) ? config.RaftSurfacePrintSpeed : config.RaftPrintSpeed, config.RaftSurfaceExtrusionWidth_um, "SUPPORT");
 
 				// create the raft base

--- a/LayerDataStorage.cs
+++ b/LayerDataStorage.cs
@@ -224,9 +224,14 @@ namespace MatterHackers.MatterSlice
 			LayerDataStorage storage = this;
 			if (config.ShouldGenerateRaft())
 			{
-				GCodePathConfig raftBaseConfig = new GCodePathConfig(config.FirstLayerSpeed, config.RaftBaseExtrusionWidth_um, "SUPPORT");
-				GCodePathConfig raftMiddleConfig = new GCodePathConfig(config.RaftPrintSpeed, config.RaftInterfaceExtrusionWidth_um, "SUPPORT");
-				GCodePathConfig raftSurfaceConfig = new GCodePathConfig((config.RaftSurfacePrintSpeed > 0) ? config.RaftSurfacePrintSpeed : config.RaftPrintSpeed, config.RaftSurfaceExtrusionWidth_um, "SUPPORT");
+				GCodePathConfig raftBaseConfig = new GCodePathConfig();
+				raftBaseConfig.SetData(config.FirstLayerSpeed, config.RaftBaseExtrusionWidth_um, "SUPPORT");
+
+				GCodePathConfig raftMiddleConfig = new GCodePathConfig();
+				raftMiddleConfig.SetData(config.RaftPrintSpeed, config.RaftInterfaceExtrusionWidth_um, "SUPPORT");
+
+				GCodePathConfig raftSurfaceConfig = new GCodePathConfig();
+				raftSurfaceConfig.SetData((config.RaftSurfacePrintSpeed > 0) ? config.RaftSurfacePrintSpeed : config.RaftPrintSpeed, config.RaftSurfaceExtrusionWidth_um, "SUPPORT");
 
 				// create the raft base
 				{

--- a/fffProcessor.cs
+++ b/fffProcessor.cs
@@ -647,7 +647,7 @@ namespace MatterHackers.MatterSlice
 					}
 				}
 
-				gcodeLayer.WriteQueuedGCode(currentLayerThickness_um);
+				gcodeLayer.WriteQueuedGCode(currentLayerThickness_um, fanSpeedPercent, config.BridgeFanSpeedPercent);
 			}
 
 			LogOutput.Log("Wrote layers in {0:0.00}s.\n".FormatWith(timeKeeper.Elapsed.TotalSeconds));
@@ -780,7 +780,6 @@ namespace MatterHackers.MatterSlice
 				// It would be even better to slow down the perimeters that are part of bridges but that is a bit harder.
 				if (bridgePolygons.Count > 0)
 				{
-					gcode.WriteFanCommand(config.BridgeFanSpeedPercent);
 					QueuePolygonsConsideringSupport(layerIndex, gcodeLayer, bridgePolygons, bridgeConfig, SupportWriteType.UnsupportedAreas);
 				}
 

--- a/fffProcessor.cs
+++ b/fffProcessor.cs
@@ -43,21 +43,21 @@ namespace MatterHackers.MatterSlice
 		private OptimizedMeshCollection optomizedMeshCollection;
 		private LayerDataStorage slicingData = new LayerDataStorage();
 
-		private GCodePathConfig skirtConfig = new GCodePathConfig();
+		private GCodePathConfig skirtConfig = new GCodePathConfig("skirtConfig");
 
-		private GCodePathConfig inset0Config = new GCodePathConfig()
+		private GCodePathConfig inset0Config = new GCodePathConfig("inset0Config")
 		{
 			doSeamHiding = true,
 		};
 
-		private GCodePathConfig insetXConfig = new GCodePathConfig();
-		private GCodePathConfig fillConfig = new GCodePathConfig();
-		private GCodePathConfig topFillConfig = new GCodePathConfig();
-		private GCodePathConfig bottomFillConfig = new GCodePathConfig();
-		private GCodePathConfig airGappedBottomConfig = new GCodePathConfig();
-        private GCodePathConfig bridgeConfig = new GCodePathConfig();
-		private GCodePathConfig supportNormalConfig = new GCodePathConfig();
-		private GCodePathConfig supportInterfaceConfig = new GCodePathConfig();
+		private GCodePathConfig insetXConfig = new GCodePathConfig("insetXConfig");
+		private GCodePathConfig fillConfig = new GCodePathConfig("fillConfig");
+		private GCodePathConfig topFillConfig = new GCodePathConfig("topFillConfig");
+		private GCodePathConfig bottomFillConfig = new GCodePathConfig("bottomFillConfig");
+		private GCodePathConfig airGappedBottomConfig = new GCodePathConfig("airGappedBottomConfig");
+        private GCodePathConfig bridgeConfig = new GCodePathConfig("bridgeConfig");
+		private GCodePathConfig supportNormalConfig = new GCodePathConfig("supportNormalConfig");
+		private GCodePathConfig supportInterfaceConfig = new GCodePathConfig("supportInterfaceConfig");
 
 		public fffProcessor(ConfigSettings config)
 		{

--- a/fffProcessor.cs
+++ b/fffProcessor.cs
@@ -547,11 +547,11 @@ namespace MatterHackers.MatterSlice
 				{
 					if (layerIndex == 0)
 					{
-						QueueExtruderLayerToGCode(slicingData, gcodeLayer, extruderIndex, layerIndex, config.FirstLayerExtrusionWidth_um, fanSpeedPercent, z);
+						QueueExtruderLayerToGCode(slicingData, gcodeLayer, extruderIndex, layerIndex, config.FirstLayerExtrusionWidth_um, z);
 					}
 					else
 					{
-						QueueExtruderLayerToGCode(slicingData, gcodeLayer, extruderIndex, layerIndex, config.ExtrusionWidth_um, fanSpeedPercent, z);
+						QueueExtruderLayerToGCode(slicingData, gcodeLayer, extruderIndex, layerIndex, config.ExtrusionWidth_um, z);
 					}
 
 					if (slicingData.support != null)
@@ -607,7 +607,7 @@ namespace MatterHackers.MatterSlice
 
 					for (int extruderIndex = 0; extruderIndex < slicingData.Extruders.Count; extruderIndex++)
 					{
-						QueueAirGappedExtruderLayerToGCode(slicingData, gcodeLayer, extruderIndex, layerIndex, config.ExtrusionWidth_um, fanSpeedPercent, z);
+						QueueAirGappedExtruderLayerToGCode(slicingData, gcodeLayer, extruderIndex, layerIndex, config.ExtrusionWidth_um, z);
 					}
 
 					slicingData.support.QueueAirGappedBottomLayer(config, gcodeLayer, layerIndex, airGappedBottomConfig);
@@ -708,7 +708,7 @@ namespace MatterHackers.MatterSlice
 		private int lastPartIndex = 0;
 
 		//Add a single layer from a single extruder to the GCode
-		private void QueueExtruderLayerToGCode(LayerDataStorage slicingData, GCodePlanner gcodeLayer, int extruderIndex, int layerIndex, int extrusionWidth_um, int fanSpeedPercent, long currentZ_um)
+		private void QueueExtruderLayerToGCode(LayerDataStorage slicingData, GCodePlanner gcodeLayer, int extruderIndex, int layerIndex, int extrusionWidth_um, long currentZ_um)
 		{
 			SliceLayer layer = slicingData.Extruders[extruderIndex].Layers[layerIndex];
 
@@ -719,7 +719,6 @@ namespace MatterHackers.MatterSlice
 				// don't do anything on this layer
 				return;
 			}
-
 
 			int prevExtruder = gcodeLayer.getExtruder();
 			bool extruderChanged = gcodeLayer.SetExtruder(extruderIndex);
@@ -957,7 +956,7 @@ namespace MatterHackers.MatterSlice
 		}
 
 		//Add a single layer from a single extruder to the GCode
-		private void QueueAirGappedExtruderLayerToGCode(LayerDataStorage slicingData, GCodePlanner gcodeLayer, int extruderIndex, int layerIndex, int extrusionWidth_um, int fanSpeedPercent, long currentZ_um)
+		private void QueueAirGappedExtruderLayerToGCode(LayerDataStorage slicingData, GCodePlanner gcodeLayer, int extruderIndex, int layerIndex, int extrusionWidth_um, long currentZ_um)
 		{
 			if (config.GenerateSupport
 				&& !config.ContinuousSpiralOuterPerimeter

--- a/gcodeExport.cs
+++ b/gcodeExport.cs
@@ -271,6 +271,9 @@ namespace MatterHackers.MatterSlice
 				return;
 			}
 
+			// Exhaust the buffer before changing the fan speed
+			gcodeFileStream.Write("G4 P0\n");
+
 			if (speed > 0)
 			{
 				gcodeFileStream.Write("M106 S{0}\n".FormatWith(speed * 255 / 100));


### PR DESCRIPTION
Potentially fixes MatterHackers/MatterControl#668

An issue still exists where the firmware planner consumes and queues G1 operations, arrives at M107 or similar bridge fan speed adjustment and carries out the fan operation before completing queued bridge moves. We might be able to address this with a stream processor but for a first pass this hooks up the bridge fan speed with the underlying bridge moves 