### PR TITLE
Make sure we only create insets once.

### DIFF
--- a/SliceLayer.cs
+++ b/SliceLayer.cs
@@ -34,6 +34,7 @@ namespace MatterHackers.MatterSlice
 		public Polygons AllOutlines { get; set; }
 		public PathFinder PathFinder { get; set; }
 		public List<LayerIsland> Islands = null;
+		public bool CreatedInsets { get; set; } = false;
 		public long LayerZ;
 		private static bool OUTPUT_DEBUG_DATA = false;
 

--- a/fffProcessor.cs
+++ b/fffProcessor.cs
@@ -605,8 +605,9 @@ namespace MatterHackers.MatterSlice
 					SliceLayer layer = slicingData.Extruders[extruderIndex].Layers[layerIndex];
 
 					if (layer.Islands.Count > 0
-						&& layer.Islands[0].InsetToolPaths.Count == 0)
+						&& !layer.CreatedInsets)
 					{
+						layer.CreatedInsets = true;
 						int insetCount = config.NumberOfPerimeters;
 						if (config.ContinuousSpiralOuterPerimeter && (int)(layerIndex) < config.NumberOfBottomLayers && layerIndex % 2 == 1)
 						{


### PR DESCRIPTION
issue: MatterHackers/MatterSlice#276
Unexpected suddenly fast layer. Causes visible layer in print.