### PR TITLE
Don't put points in twice.

### DIFF
--- a/Pathfinding/IntPointPathing/IntPointPathNetwork.cs
+++ b/Pathfinding/IntPointPathing/IntPointPathNetwork.cs
@@ -110,7 +110,11 @@ namespace MatterHackers.Pathfinding
 				int lastLinkIndex = polygon.Count - 1 + startNode;
 				for (int i = startNode; i < polygon.Count + startNode; i++)
 				{
-					AddPathLink(Nodes[lastLinkIndex], Nodes[i]);
+					if (Nodes[lastLinkIndex].Position != Nodes[i].Position)
+					{
+						AddPathLink(Nodes[lastLinkIndex], Nodes[i]);
+					}
+
 					lastLinkIndex = i;
 				}
 			}


### PR DESCRIPTION
issue: MatterHackers/MCCentral#2347
Printing/slicing fails with PathFinding assert exception