### PR TITLE
Wipe tower goes all the way up

### DIFF
--- a/LayerDataStorage.cs
+++ b/LayerDataStorage.cs
@@ -501,7 +501,7 @@ namespace MatterHackers.MatterSlice
 			bool haveWipeTower = HaveWipeTower(config);
 			if (haveWipeTower)
 			{
-				return layerIndex < LastLayerWithChange(config);
+				return layerIndex <= LastLayerWithChange(config);
 			}
 
 			return false;


### PR DESCRIPTION
issue: MatterHackers/MCCentral#3986
Wipe tower not present on last layer of dual extrusion print