### PR TITLE
move to inner outline rather than outer outline to optimize seam

### DIFF
--- a/fffProcessor.cs
+++ b/fffProcessor.cs
@@ -294,20 +294,23 @@ namespace MatterHackers.MatterSlice
 			slicingData.CreateIslandData();
 
 			supportIslands = new List<LayerIsland>();
-			
-			foreach (var region in supportOutlines.Layers)
+
+			if (supportOutlines != null)
 			{
-				foreach (Polygons island in region.AllOutlines.ProcessIntoSeparateIslands())
+				foreach (var region in supportOutlines.Layers)
 				{
-					var layerIsland = new LayerIsland()
+					foreach (Polygons island in region.AllOutlines.ProcessIntoSeparateIslands())
 					{
-						IslandOutline = island,
-						PathFinder = new PathFinder(island, config.ExtrusionWidth_um * 3 / 2, useInsideCache: config.AvoidCrossingPerimeters),
-					};
+						var layerIsland = new LayerIsland()
+						{
+							IslandOutline = island,
+							PathFinder = new PathFinder(island, config.ExtrusionWidth_um * 3 / 2, useInsideCache: config.AvoidCrossingPerimeters),
+						};
 
-					layerIsland.BoundingBox.Calculate(layerIsland.IslandOutline);
+						layerIsland.BoundingBox.Calculate(layerIsland.IslandOutline);
 
-					supportIslands.Add(layerIsland);
+						supportIslands.Add(layerIsland);
+					}
 				}
 			}
 
@@ -959,9 +962,10 @@ namespace MatterHackers.MatterSlice
 										&& insetIndex == island.InsetToolPaths.Count - 1)
 									{
 										var closestInsetStart = FindBestPoint(insetsForThisIsland[0], layerGcodePlanner.LastPosition, layerIndex);
-										if(closestInsetStart.X != long.MinValue)
+										if (closestInsetStart.X != long.MinValue)
 										{
-											layerGcodePlanner.QueueTravel(closestInsetStart);
+											var pointOnInside = insetsForThisIsland[insetsForThisIsland.Count - 1].FindClosestPoint(closestInsetStart).position;
+											layerGcodePlanner.QueueTravel(pointOnInside);
 										}
 									}
 


### PR DESCRIPTION
issue: MatterHackers/MCCentral#4000
Move to outermost perimeter, then to innermost at start of line

fixed for when support is off