### PR TITLE
Constrain extruder index to valid range

### DIFF
--- a/fffProcessor.cs
+++ b/fffProcessor.cs
@@ -580,14 +580,14 @@ namespace MatterHackers.MatterSlice
 					{
 						bool movedToIsland = false;
 
+						var usableExtruderIndex = config.SupportExtruder < config.ExtruderCount ? config.SupportExtruder : 0;
+
 						if (layerIndex < supportIslands.Count)
 						{
-							SliceLayer layer = slicingData.Extruders[extruderIndex].Layers[layerIndex];
+							SliceLayer layer = slicingData.Extruders[usableExtruderIndex].Layers[layerIndex];
 							MoveToIsland(layerGcodePlanner, layer, supportIslands[layerIndex]);
 							movedToIsland = true;
 						}
-
-						var usableExtruderIndex = config.SupportExtruder < config.ExtruderCount ? config.SupportExtruder : 0;
 
 						if ((usableExtruderIndex <= 0 && extruderIndex == 0)
 							|| usableExtruderIndex == extruderIndex)


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#4044
Index out of range exception due to unconstrained extruder index