### PR TITLE
Consolidate and revise wipe tower generation

### DIFF
--- a/GCodePlanner.cs
+++ b/GCodePlanner.cs
@@ -330,7 +330,7 @@ namespace MatterHackers.MatterSlice
 			//ValidatePaths();
 		}
 
-		public bool ExtruderWillChange(int extruder)
+		public bool ToolChangeRequired(int extruder)
 		{
 			if (extruder == currentExtruderIndex)
 			{

--- a/LayerDataStorage.cs
+++ b/LayerDataStorage.cs
@@ -468,8 +468,15 @@ namespace MatterHackers.MatterSlice
 			return skirtPolygons;
 		}
 
+		int lastLayerWithCange = -1;
+		bool calculatedLastLayer = false;
 		public int LastLayerWithChange(ConfigSettings config)
 		{
+			if (calculatedLastLayer)
+			{
+				return lastLayerWithCange;
+			}
+
 			int numLayers = Extruders[0].Layers.Count;
 			int firstExtruderWithData = -1;
 			for (int checkLayer = numLayers - 1; checkLayer >= 0; checkLayer--)
@@ -488,20 +495,22 @@ namespace MatterHackers.MatterSlice
 						{
 							if (firstExtruderWithData != extruderToCheck)
 							{
-								return checkLayer;
+								lastLayerWithCange = checkLayer;
+								calculatedLastLayer = true;
+								return lastLayerWithCange;
 							}
 						}
 					}
 				}
 			}
 
+			calculatedLastLayer = true;
 			return -1;
 		}
 
 		public bool NeedToPrintWipeTower(int layerIndex, ConfigSettings config)
 		{
-			bool haveWipeTower = HaveWipeTower(config);
-			if (haveWipeTower)
+			if (HaveWipeTower(config))
 			{
 				return layerIndex <= LastLayerWithChange(config);
 			}


### PR DESCRIPTION
- Issue MatterHackers/MatterControl#3617
Bug? When Printing Extruder Moves To Ghost Wipe Tower / Home
Position After Each Layer Completes
- Issue MatterHackers/MCCentral#4038
Generating support causes printhead to move to 0,0 after every layer
- Issue MatterHackers/MCCentral#4062
Move to origin
- Issue MatterHackers/MCCentral#3991
Slicer moves to origin every layer