### PR TITLE
Convert project references to lowercase

### DIFF
--- a/Pathfinding/Pathfinding.csproj
+++ b/Pathfinding/Pathfinding.csproj
@@ -63,7 +63,7 @@
       <Name>ImageProcessing</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\agg-sharp\VectorMath\VectorMath.csproj">
-      <Project>{D3E41B4E-BFBB-44CA-94C8-95C00F754FDD}</Project>
+      <Project>{d3e41b4e-bfbb-44ca-94c8-95c00f754fdd}</Project>
       <Name>VectorMath</Name>
     </ProjectReference>
     <ProjectReference Include="..\MSClipperLib\MSClipperLib.csproj">

--- a/Tests/MatterSlice.Tests/MatterSlice.Tests.csproj
+++ b/Tests/MatterSlice.Tests/MatterSlice.Tests.csproj
@@ -64,7 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MatterSlice.csproj">
-      <Project>{C46CA728-DD2F-4DD1-971A-AAA89D9DFF95}</Project>
+      <Project>{c46ca728-dd2f-4dd1-971a-aaa89d9dff95}</Project>
       <Name>MatterSlice</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\MSClipperLib\MSClipperLib.csproj">


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#4082
Errors appear in VS after successful builds due to IntelliSense problems