### PR TITLE
made text fit better

### DIFF
--- a/MatterSliceLib/ExtruderLayers.cs
+++ b/MatterSliceLib/ExtruderLayers.cs
@@ -227,7 +227,7 @@ namespace MatterHackers.MatterSlice
 					return;
 				}
 
-				LogOutput.Log("Generating Layer Outlines {0}/{1}\n".FormatWith(layerIndex + 1, extruders[0].Layers.Count));
+				LogOutput.Log("Generating Outlines {0}/{1}\n".FormatWith(layerIndex + 1, extruders[0].Layers.Count));
 
 				long avoidInset = config.ExtrusionWidth_um * 3 / 2;
 


### PR DESCRIPTION
issue: MatterHackers/MatterControl#3713
MatterControl 2.0.0.9886 (BETA) - When Slicing, the output text is cutoff in the display box