### PR TITLE
Don't look for and strip out comments

### DIFF
--- a/MatterSliceLib/ConfigSettings.cs
+++ b/MatterSliceLib/ConfigSettings.cs
@@ -450,11 +450,6 @@ namespace MatterHackers.MatterSlice
 				for (int i = 0; i < lines.Length; i++)
 				{
 					string line = lines[i];
-					int commentStart = line.IndexOf("#");
-					if (commentStart >= 0)
-					{
-						line = line.Substring(0, commentStart);
-					}
 
 					int equalsPos = line.IndexOf('=');
 					if (equalsPos > 0)


### PR DESCRIPTION
we don't make any and they make '#'s invalid in file names

issue: MatterHackers/MatterSlice#424
Slicing failure due to pound in source filename