### PR TITLE
Simplify GCodePathConfig use

### DIFF
--- a/MatterSliceLib/GCodePathConfig.cs
+++ b/MatterSliceLib/GCodePathConfig.cs
@@ -33,7 +33,7 @@ namespace MatterHackers.MatterSlice
 		public double Speed { get; private set; }
 		public bool spiralize;
 
-		public GCodePathConfig(string configName, string gcodeComment = "", bool closedLoop = true)
+		public GCodePathConfig(string configName, string gcodeComment, bool closedLoop = true)
 		{
 			this.Name = configName;
 			this.gcodeComment = gcodeComment;

--- a/MatterSliceLib/GCodePathConfig.cs
+++ b/MatterSliceLib/GCodePathConfig.cs
@@ -33,9 +33,10 @@ namespace MatterHackers.MatterSlice
 		public double Speed { get; private set; }
 		public bool spiralize;
 
-		public GCodePathConfig(string configName)
+		public GCodePathConfig(string configName, string gcodeComment = "")
 		{
 			this.Name = configName;
+			this.gcodeComment = gcodeComment;
 		}
 
 		public string Name { get; set; }
@@ -47,12 +48,11 @@ namespace MatterHackers.MatterSlice
 		/// <param name="lineWidth_um"></param>
 		/// <param name="gcodeComment"></param>
 		/// <param name="closedLoop"></param>
-		public void SetData(double speed, long lineWidth_um, string gcodeComment, bool closedLoop = true)
+		public void SetData(double speed, long lineWidth_um, bool closedLoop = true)
 		{
 			this.closedLoop = closedLoop;
 			this.Speed = speed;
 			this.lineWidth_um = lineWidth_um;
-			this.gcodeComment = gcodeComment;
 		}
 	}
 }

--- a/MatterSliceLib/GCodePathConfig.cs
+++ b/MatterSliceLib/GCodePathConfig.cs
@@ -33,7 +33,7 @@ namespace MatterHackers.MatterSlice
 		public double Speed { get; private set; }
 		public bool spiralize;
 
-		public GCodePathConfig(string configName, string gcodeComment = "")
+		public GCodePathConfig(string configName, string gcodeComment = "", bool closedLoop = true)
 		{
 			this.Name = configName;
 			this.gcodeComment = gcodeComment;
@@ -47,10 +47,8 @@ namespace MatterHackers.MatterSlice
 		/// <param name="speed"></param>
 		/// <param name="lineWidth_um"></param>
 		/// <param name="gcodeComment"></param>
-		/// <param name="closedLoop"></param>
-		public void SetData(double speed, long lineWidth_um, bool closedLoop = true)
+		public void SetData(double speed, long lineWidth_um)
 		{
-			this.closedLoop = closedLoop;
 			this.Speed = speed;
 			this.lineWidth_um = lineWidth_um;
 		}

--- a/MatterSliceLib/LayerDataStorage.cs
+++ b/MatterSliceLib/LayerDataStorage.cs
@@ -349,14 +349,14 @@ namespace MatterHackers.MatterSlice
 			LayerDataStorage storage = this;
 			if (config.ShouldGenerateRaft())
 			{
-				GCodePathConfig raftBaseConfig = new GCodePathConfig("raftBaseConfig");
-				raftBaseConfig.SetData(config.FirstLayerSpeed, config.RaftBaseExtrusionWidth_um, "SUPPORT");
+				var raftBaseConfig = new GCodePathConfig("raftBaseConfig", "SUPPORT");
+				raftBaseConfig.SetData(config.FirstLayerSpeed, config.RaftBaseExtrusionWidth_um);
 
-				GCodePathConfig raftMiddleConfig = new GCodePathConfig("raftMiddleConfig");
-				raftMiddleConfig.SetData(config.RaftPrintSpeed, config.RaftInterfaceExtrusionWidth_um, "SUPPORT");
+				var raftMiddleConfig = new GCodePathConfig("raftMiddleConfig", "SUPPORT");
+				raftMiddleConfig.SetData(config.RaftPrintSpeed, config.RaftInterfaceExtrusionWidth_um);
 
-				GCodePathConfig raftSurfaceConfig = new GCodePathConfig("raftMiddleConfig");
-				raftSurfaceConfig.SetData((config.RaftSurfacePrintSpeed > 0) ? config.RaftSurfacePrintSpeed : config.RaftPrintSpeed, config.RaftSurfaceExtrusionWidth_um, "SUPPORT");
+				var raftSurfaceConfig = new GCodePathConfig("raftMiddleConfig", "SUPPORT");
+				raftSurfaceConfig.SetData((config.RaftSurfacePrintSpeed > 0) ? config.RaftSurfacePrintSpeed : config.RaftPrintSpeed, config.RaftSurfaceExtrusionWidth_um);
 
 				// create the raft base
 				{

--- a/MatterSliceLib/LayerGCodePlanner.cs
+++ b/MatterSliceLib/LayerGCodePlanner.cs
@@ -61,8 +61,8 @@ namespace MatterHackers.MatterSlice
 			this.config = config;
 
 			this.gcodeExport = gcode;
-			travelConfig = new GCodePathConfig("travelConfig");
-			travelConfig.SetData(travelSpeed, 0, "travel");
+			travelConfig = new GCodePathConfig("travelConfig", "travel");
+			travelConfig.SetData(travelSpeed, 0);
 
 			LastPosition = gcode.GetPositionXY();
 			forceRetraction = false;
@@ -160,7 +160,7 @@ namespace MatterHackers.MatterSlice
 		{
 			var layerTimes = GetLayerTimes();
 
-			if (layerTimes.totalTime < config.MinimumLayerTimeSeconds 
+			if (layerTimes.totalTime < config.MinimumLayerTimeSeconds
 				&& layerTimes.variableTime > 0.0)
 			{
 				var goalRatio = layerTimes.variableTime / (config.MinimumLayerTimeSeconds - layerTimes.fixedTime);
@@ -317,7 +317,7 @@ namespace MatterHackers.MatterSlice
 
 		// We need to keep track of all the fan speeds we have queue so that we can set
 		// the minimum fan speed for the layer after all the paths for the layer have been added.
-		// We cannot calculate the minimum fan speed until the entire layer is queued and we then need to 
+		// We cannot calculate the minimum fan speed until the entire layer is queued and we then need to
 		// go back to every queued fan speed and adjust it
 		List<GCodePath> queuedFanSpeeds = new List<GCodePath>();
 

--- a/MatterSliceLib/fffProcessor.cs
+++ b/MatterSliceLib/fffProcessor.cs
@@ -64,23 +64,23 @@ namespace MatterHackers.MatterSlice
 		private OptimizedMeshCollection optimizedMeshCollection;
 		private LayerDataStorage slicingData = new LayerDataStorage();
 
-		private GCodePathConfig skirtConfig = new GCodePathConfig("skirtConfig");
+		private GCodePathConfig skirtConfig = new GCodePathConfig("skirtConfig", "SKIRT");
 
-		private GCodePathConfig inset0Config = new GCodePathConfig("inset0Config")
+		private GCodePathConfig inset0Config = new GCodePathConfig("inset0Config", "WALL-OUTER")
 		{
 			DoSeamHiding = true,
 		};
 
-		private GCodePathConfig insetXConfig = new GCodePathConfig("insetXConfig");
-		private GCodePathConfig fillConfig = new GCodePathConfig("fillConfig");
-		private GCodePathConfig topFillConfig = new GCodePathConfig("topFillConfig");
-		private GCodePathConfig firstTopFillConfig = new GCodePathConfig("firstTopFillConfig");
-		private GCodePathConfig bottomFillConfig = new GCodePathConfig("bottomFillConfig");
-		private GCodePathConfig airGappedBottomInsetConfig = new GCodePathConfig("airGappedBottomInsetConfig");
-		private GCodePathConfig airGappedBottomConfig = new GCodePathConfig("airGappedBottomConfig");
-		private GCodePathConfig bridgeConfig = new GCodePathConfig("bridgeConfig");
-		private GCodePathConfig supportNormalConfig = new GCodePathConfig("supportNormalConfig");
-		private GCodePathConfig supportInterfaceConfig = new GCodePathConfig("supportInterfaceConfig");
+		private GCodePathConfig insetXConfig = new GCodePathConfig("insetXConfig", "WALL-INNER");
+		private GCodePathConfig fillConfig = new GCodePathConfig("fillConfig", "FILL");
+		private GCodePathConfig topFillConfig = new GCodePathConfig("topFillConfig", "TOP-FILL");
+		private GCodePathConfig firstTopFillConfig = new GCodePathConfig("firstTopFillConfig", "FIRST-TOP-Fill");
+		private GCodePathConfig bottomFillConfig = new GCodePathConfig("bottomFillConfig", "BOTTOM-FILL");
+		private GCodePathConfig airGappedBottomInsetConfig = new GCodePathConfig("airGappedBottomInsetConfig", "AIR-GAP-INSET");
+		private GCodePathConfig airGappedBottomConfig = new GCodePathConfig("airGappedBottomConfig", "AIR-GAP");
+		private GCodePathConfig bridgeConfig = new GCodePathConfig("bridgeConfig", "BRIDGE");
+		private GCodePathConfig supportNormalConfig = new GCodePathConfig("supportNormalConfig", "SUPPORT");
+		private GCodePathConfig supportInterfaceConfig = new GCodePathConfig("supportInterfaceConfig", "SUPPORT-INTERFACE");
 
 		public fffProcessor(ConfigSettings config)
 		{
@@ -186,20 +186,20 @@ namespace MatterHackers.MatterSlice
 
 		private void preSetup(long extrusionWidth_um)
 		{
-			skirtConfig.SetData(config.InsidePerimetersSpeed, extrusionWidth_um, "SKIRT");
-			inset0Config.SetData(config.OutsidePerimeterSpeed, config.OutsideExtrusionWidth_um, "WALL-OUTER");
-			insetXConfig.SetData(config.InsidePerimetersSpeed, extrusionWidth_um, "WALL-INNER");
+			skirtConfig.SetData(config.InsidePerimetersSpeed, extrusionWidth_um);
+			inset0Config.SetData(config.OutsidePerimeterSpeed, config.OutsideExtrusionWidth_um);
+			insetXConfig.SetData(config.InsidePerimetersSpeed, extrusionWidth_um);
 
-			fillConfig.SetData(config.InfillSpeed, extrusionWidth_um, "FILL", false);
-			topFillConfig.SetData(config.TopInfillSpeed, extrusionWidth_um, "TOP-FILL", false);
-			firstTopFillConfig.SetData(config.BridgeSpeed, extrusionWidth_um, "FIRST-TOP-Fill", false);
-			bottomFillConfig.SetData(config.BottomInfillSpeed, extrusionWidth_um, "BOTTOM-FILL", false);
-			airGappedBottomConfig.SetData(config.AirGapSpeed, extrusionWidth_um, "AIR-GAP", false);
-			airGappedBottomInsetConfig.SetData(config.AirGapSpeed, extrusionWidth_um, "AIR-GAP-INSET");
-			bridgeConfig.SetData(config.BridgeSpeed, extrusionWidth_um, "BRIDGE");
+			fillConfig.SetData(config.InfillSpeed, extrusionWidth_um, false);
+			topFillConfig.SetData(config.TopInfillSpeed, extrusionWidth_um, false);
+			firstTopFillConfig.SetData(config.BridgeSpeed, extrusionWidth_um, false);
+			bottomFillConfig.SetData(config.BottomInfillSpeed, extrusionWidth_um, false);
+			airGappedBottomConfig.SetData(config.AirGapSpeed, extrusionWidth_um, false);
+			airGappedBottomInsetConfig.SetData(config.AirGapSpeed, extrusionWidth_um);
+			bridgeConfig.SetData(config.BridgeSpeed, extrusionWidth_um);
 
-			supportNormalConfig.SetData(config.SupportMaterialSpeed, extrusionWidth_um, "SUPPORT");
-			supportInterfaceConfig.SetData(config.SupportMaterialSpeed, extrusionWidth_um, "SUPPORT-INTERFACE");
+			supportNormalConfig.SetData(config.SupportMaterialSpeed, extrusionWidth_um);
+			supportInterfaceConfig.SetData(config.SupportMaterialSpeed, extrusionWidth_um);
 
 			gcodeExport.SetLayerChangeCode(config.LayerChangeCode);
 		}
@@ -454,37 +454,37 @@ namespace MatterHackers.MatterSlice
 
 				if (layerIndex < config.NumberOfFirstLayers)
 				{
-					skirtConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, "SKIRT");
-					inset0Config.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, "WALL-OUTER");
-					insetXConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, "WALL-INNER");
+					skirtConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
+					inset0Config.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
+					insetXConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
 
-					fillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, "FILL", false);
-					topFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, "TOP-FILL", false);
-					firstTopFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerThickness_um, "FIRST-TOP-Fill", false);
-					bottomFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, "BOTTOM-FILL", false);
-					airGappedBottomConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, "AIR-GAP", false);
-					airGappedBottomInsetConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, "AIR-GAP-INSET");
-					bridgeConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, "BRIDGE");
+					fillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, false);
+					topFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, false);
+					firstTopFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerThickness_um, false);
+					bottomFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, false);
+					airGappedBottomConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, false);
+					airGappedBottomInsetConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
+					bridgeConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
 
-					supportNormalConfig.SetData(config.FirstLayerSpeed, config.ExtrusionWidth_um, "SUPPORT");
-					supportInterfaceConfig.SetData(config.FirstLayerSpeed, config.ExtrusionWidth_um, "SUPPORT-INTERFACE");
+					supportNormalConfig.SetData(config.FirstLayerSpeed, config.ExtrusionWidth_um);
+					supportInterfaceConfig.SetData(config.FirstLayerSpeed, config.ExtrusionWidth_um);
 				}
 				else
 				{
-					skirtConfig.SetData(config.InsidePerimetersSpeed, config.ExtrusionWidth_um, "SKIRT");
-					inset0Config.SetData(config.OutsidePerimeterSpeed, config.OutsideExtrusionWidth_um, "WALL-OUTER");
-					insetXConfig.SetData(config.InsidePerimetersSpeed, config.ExtrusionWidth_um, "WALL-INNER");
+					skirtConfig.SetData(config.InsidePerimetersSpeed, config.ExtrusionWidth_um);
+					inset0Config.SetData(config.OutsidePerimeterSpeed, config.OutsideExtrusionWidth_um);
+					insetXConfig.SetData(config.InsidePerimetersSpeed, config.ExtrusionWidth_um);
 
-					fillConfig.SetData(config.InfillSpeed, config.ExtrusionWidth_um, "FILL", false);
-					topFillConfig.SetData(config.TopInfillSpeed, config.ExtrusionWidth_um, "TOP-FILL", false);
-					firstTopFillConfig.SetData(config.BridgeSpeed, config.ExtrusionWidth_um, "FIRST-TOP-Fill", false);
-					bottomFillConfig.SetData(config.BottomInfillSpeed, config.ExtrusionWidth_um, "BOTTOM-FILL", false);
-					airGappedBottomConfig.SetData(config.AirGapSpeed, config.ExtrusionWidth_um, "AIR-GAP", false);
-					airGappedBottomInsetConfig.SetData(config.AirGapSpeed, config.ExtrusionWidth_um, "AIR-GAP-INSET");
-					bridgeConfig.SetData(config.BridgeSpeed, config.ExtrusionWidth_um, "BRIDGE");
+					fillConfig.SetData(config.InfillSpeed, config.ExtrusionWidth_um, false);
+					topFillConfig.SetData(config.TopInfillSpeed, config.ExtrusionWidth_um, false);
+					firstTopFillConfig.SetData(config.BridgeSpeed, config.ExtrusionWidth_um, false);
+					bottomFillConfig.SetData(config.BottomInfillSpeed, config.ExtrusionWidth_um, false);
+					airGappedBottomConfig.SetData(config.AirGapSpeed, config.ExtrusionWidth_um, false);
+					airGappedBottomInsetConfig.SetData(config.AirGapSpeed, config.ExtrusionWidth_um);
+					bridgeConfig.SetData(config.BridgeSpeed, config.ExtrusionWidth_um);
 
-					supportNormalConfig.SetData(config.SupportMaterialSpeed, config.ExtrusionWidth_um, "SUPPORT");
-					supportInterfaceConfig.SetData(config.SupportMaterialSpeed, config.ExtrusionWidth_um, "SUPPORT-INTERFACE");
+					supportNormalConfig.SetData(config.SupportMaterialSpeed, config.ExtrusionWidth_um);
+					supportInterfaceConfig.SetData(config.SupportMaterialSpeed, config.ExtrusionWidth_um);
 				}
 
 				if (layerIndex == 0)
@@ -646,9 +646,9 @@ namespace MatterHackers.MatterSlice
 			maxObjectHeight = Math.Max(maxObjectHeight, slicingData.modelSize.Z);
 		}
 
-		private void ChangeExtruderIfRequired(LayerDataStorage slicingData, 
-			int layerIndex, 
-			LayerGCodePlanner layerGcodePlanner, 
+		private void ChangeExtruderIfRequired(LayerDataStorage slicingData,
+			int layerIndex,
+			LayerGCodePlanner layerGcodePlanner,
 			int extruderIndex,
 			bool airGapped)
 		{
@@ -662,7 +662,7 @@ namespace MatterHackers.MatterSlice
 			bool extruderUsedForWipeTower = extruderUsedForParts
 				&& slicingData.NeedToPrintWipeTower(layerIndex, config);
 
-			if ((extruderUsedForSupport 
+			if ((extruderUsedForSupport
 				|| extruderUsedForWipeTower
 				|| extruderUsedForParts)
 				&& layerGcodePlanner.ToolChangeRequired(extruderIndex))
@@ -698,7 +698,7 @@ namespace MatterHackers.MatterSlice
 					DoSkirtAndBrim(slicingData, layerIndex, layerGcodePlanner, extruderIndex, extruderUsedForSupport);
 				}
 			}
-			else 
+			else
 			{
 				DoSkirtAndBrim(slicingData, layerIndex, layerGcodePlanner, extruderIndex, extruderUsedForSupport);
 			}
@@ -1260,7 +1260,7 @@ namespace MatterHackers.MatterSlice
 
 			if (polygonPrintedIndex > -1)
 			{
-				if (config.MergeOverlappingLines 
+				if (config.MergeOverlappingLines
 					&& pathConfig != inset0Config) // we do not merge the outer perimeter
 				{
 					QueuePerimeterWithMergeOverlaps(insetsToConsider[polygonPrintedIndex], layerIndex, gcodeLayer, pathConfig);

--- a/MatterSliceLib/fffProcessor.cs
+++ b/MatterSliceLib/fffProcessor.cs
@@ -117,8 +117,7 @@ namespace MatterHackers.MatterSlice
 			LogOutput.Log("Optimized model in {0:0.0}s \n".FormatWith(timeKeeper.Elapsed.TotalSeconds));
 			timeKeeper.Reset();
 
-			Stopwatch timeKeeperTotal = new Stopwatch();
-			timeKeeperTotal.Start();
+			var timeKeeperTotal = Stopwatch.StartNew();
 
 			gcodeExport.SetLayerChangeCode(config.LayerChangeCode);
 

--- a/MatterSliceLib/fffProcessor.cs
+++ b/MatterSliceLib/fffProcessor.cs
@@ -72,12 +72,13 @@ namespace MatterHackers.MatterSlice
 		};
 
 		private GCodePathConfig insetXConfig = new GCodePathConfig("insetXConfig", "WALL-INNER");
-		private GCodePathConfig fillConfig = new GCodePathConfig("fillConfig", "FILL");
-		private GCodePathConfig topFillConfig = new GCodePathConfig("topFillConfig", "TOP-FILL");
-		private GCodePathConfig firstTopFillConfig = new GCodePathConfig("firstTopFillConfig", "FIRST-TOP-Fill");
-		private GCodePathConfig bottomFillConfig = new GCodePathConfig("bottomFillConfig", "BOTTOM-FILL");
+
+		private GCodePathConfig fillConfig = new GCodePathConfig("fillConfig", "FILL", closedLoop: false);
+		private GCodePathConfig topFillConfig = new GCodePathConfig("topFillConfig", "TOP-FILL", closedLoop: false);
+		private GCodePathConfig firstTopFillConfig = new GCodePathConfig("firstTopFillConfig", "FIRST-TOP-Fill", closedLoop: false);
+		private GCodePathConfig bottomFillConfig = new GCodePathConfig("bottomFillConfig", "BOTTOM-FILL", closedLoop: false);
 		private GCodePathConfig airGappedBottomInsetConfig = new GCodePathConfig("airGappedBottomInsetConfig", "AIR-GAP-INSET");
-		private GCodePathConfig airGappedBottomConfig = new GCodePathConfig("airGappedBottomConfig", "AIR-GAP");
+		private GCodePathConfig airGappedBottomConfig = new GCodePathConfig("airGappedBottomConfig", "AIR-GAP", closedLoop: false);
 		private GCodePathConfig bridgeConfig = new GCodePathConfig("bridgeConfig", "BRIDGE");
 		private GCodePathConfig supportNormalConfig = new GCodePathConfig("supportNormalConfig", "SUPPORT");
 		private GCodePathConfig supportInterfaceConfig = new GCodePathConfig("supportInterfaceConfig", "SUPPORT-INTERFACE");
@@ -190,11 +191,11 @@ namespace MatterHackers.MatterSlice
 			inset0Config.SetData(config.OutsidePerimeterSpeed, config.OutsideExtrusionWidth_um);
 			insetXConfig.SetData(config.InsidePerimetersSpeed, extrusionWidth_um);
 
-			fillConfig.SetData(config.InfillSpeed, extrusionWidth_um, false);
-			topFillConfig.SetData(config.TopInfillSpeed, extrusionWidth_um, false);
-			firstTopFillConfig.SetData(config.BridgeSpeed, extrusionWidth_um, false);
-			bottomFillConfig.SetData(config.BottomInfillSpeed, extrusionWidth_um, false);
-			airGappedBottomConfig.SetData(config.AirGapSpeed, extrusionWidth_um, false);
+			fillConfig.SetData(config.InfillSpeed, extrusionWidth_um);
+			topFillConfig.SetData(config.TopInfillSpeed, extrusionWidth_um);
+			firstTopFillConfig.SetData(config.BridgeSpeed, extrusionWidth_um);
+			bottomFillConfig.SetData(config.BottomInfillSpeed, extrusionWidth_um);
+			airGappedBottomConfig.SetData(config.AirGapSpeed, extrusionWidth_um);
 			airGappedBottomInsetConfig.SetData(config.AirGapSpeed, extrusionWidth_um);
 			bridgeConfig.SetData(config.BridgeSpeed, extrusionWidth_um);
 
@@ -458,11 +459,11 @@ namespace MatterHackers.MatterSlice
 					inset0Config.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
 					insetXConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
 
-					fillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, false);
-					topFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, false);
-					firstTopFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerThickness_um, false);
-					bottomFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, false);
-					airGappedBottomConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um, false);
+					fillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
+					topFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
+					firstTopFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerThickness_um);
+					bottomFillConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
+					airGappedBottomConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
 					airGappedBottomInsetConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
 					bridgeConfig.SetData(config.FirstLayerSpeed, config.FirstLayerExtrusionWidth_um);
 
@@ -475,11 +476,11 @@ namespace MatterHackers.MatterSlice
 					inset0Config.SetData(config.OutsidePerimeterSpeed, config.OutsideExtrusionWidth_um);
 					insetXConfig.SetData(config.InsidePerimetersSpeed, config.ExtrusionWidth_um);
 
-					fillConfig.SetData(config.InfillSpeed, config.ExtrusionWidth_um, false);
-					topFillConfig.SetData(config.TopInfillSpeed, config.ExtrusionWidth_um, false);
-					firstTopFillConfig.SetData(config.BridgeSpeed, config.ExtrusionWidth_um, false);
-					bottomFillConfig.SetData(config.BottomInfillSpeed, config.ExtrusionWidth_um, false);
-					airGappedBottomConfig.SetData(config.AirGapSpeed, config.ExtrusionWidth_um, false);
+					fillConfig.SetData(config.InfillSpeed, config.ExtrusionWidth_um);
+					topFillConfig.SetData(config.TopInfillSpeed, config.ExtrusionWidth_um);
+					firstTopFillConfig.SetData(config.BridgeSpeed, config.ExtrusionWidth_um);
+					bottomFillConfig.SetData(config.BottomInfillSpeed, config.ExtrusionWidth_um);
+					airGappedBottomConfig.SetData(config.AirGapSpeed, config.ExtrusionWidth_um);
 					airGappedBottomInsetConfig.SetData(config.AirGapSpeed, config.ExtrusionWidth_um);
 					bridgeConfig.SetData(config.BridgeSpeed, config.ExtrusionWidth_um);
 

--- a/MatterSliceLib/fffProcessor.cs
+++ b/MatterSliceLib/fffProcessor.cs
@@ -64,24 +64,18 @@ namespace MatterHackers.MatterSlice
 		private OptimizedMeshCollection optimizedMeshCollection;
 		private LayerDataStorage slicingData = new LayerDataStorage();
 
-		private GCodePathConfig skirtConfig = new GCodePathConfig("skirtConfig", "SKIRT");
-
-		private GCodePathConfig inset0Config = new GCodePathConfig("inset0Config", "WALL-OUTER")
-		{
-			DoSeamHiding = true,
-		};
-
-		private GCodePathConfig insetXConfig = new GCodePathConfig("insetXConfig", "WALL-INNER");
-
-		private GCodePathConfig fillConfig = new GCodePathConfig("fillConfig", "FILL", closedLoop: false);
-		private GCodePathConfig topFillConfig = new GCodePathConfig("topFillConfig", "TOP-FILL", closedLoop: false);
-		private GCodePathConfig firstTopFillConfig = new GCodePathConfig("firstTopFillConfig", "FIRST-TOP-Fill", closedLoop: false);
-		private GCodePathConfig bottomFillConfig = new GCodePathConfig("bottomFillConfig", "BOTTOM-FILL", closedLoop: false);
-		private GCodePathConfig airGappedBottomInsetConfig = new GCodePathConfig("airGappedBottomInsetConfig", "AIR-GAP-INSET");
-		private GCodePathConfig airGappedBottomConfig = new GCodePathConfig("airGappedBottomConfig", "AIR-GAP", closedLoop: false);
-		private GCodePathConfig bridgeConfig = new GCodePathConfig("bridgeConfig", "BRIDGE");
-		private GCodePathConfig supportNormalConfig = new GCodePathConfig("supportNormalConfig", "SUPPORT");
-		private GCodePathConfig supportInterfaceConfig = new GCodePathConfig("supportInterfaceConfig", "SUPPORT-INTERFACE");
+		private GCodePathConfig skirtConfig;
+		private GCodePathConfig inset0Config;
+		private GCodePathConfig insetXConfig;
+		private GCodePathConfig fillConfig;
+		private GCodePathConfig topFillConfig;
+		private GCodePathConfig firstTopFillConfig;
+		private GCodePathConfig bottomFillConfig;
+		private GCodePathConfig airGappedBottomInsetConfig;
+		private GCodePathConfig airGappedBottomConfig;
+		private GCodePathConfig bridgeConfig;
+		private GCodePathConfig supportNormalConfig;
+		private GCodePathConfig supportInterfaceConfig;
 
 		public fffProcessor(ConfigSettings config)
 		{
@@ -416,6 +410,19 @@ namespace MatterHackers.MatterSlice
 
 			// keep the raft generation code inside of raft
 			slicingData.WriteRaftGCodeIfRequired(gcodeExport, config);
+
+			skirtConfig = new GCodePathConfig("skirtConfig", "SKIRT");
+			inset0Config = new GCodePathConfig("inset0Config", "WALL-OUTER") { DoSeamHiding = true };
+			insetXConfig = new GCodePathConfig("insetXConfig", "WALL-INNER");
+			fillConfig = new GCodePathConfig("fillConfig", "FILL", closedLoop: false);
+			topFillConfig = new GCodePathConfig("topFillConfig", "TOP-FILL", closedLoop: false);
+			firstTopFillConfig = new GCodePathConfig("firstTopFillConfig", "FIRST-TOP-Fill", closedLoop: false);
+			bottomFillConfig = new GCodePathConfig("bottomFillConfig", "BOTTOM-FILL", closedLoop: false);
+			airGappedBottomInsetConfig = new GCodePathConfig("airGappedBottomInsetConfig", "AIR-GAP-INSET");
+			airGappedBottomConfig = new GCodePathConfig("airGappedBottomConfig", "AIR-GAP", closedLoop: false);
+			bridgeConfig = new GCodePathConfig("bridgeConfig", "BRIDGE");
+			supportNormalConfig = new GCodePathConfig("supportNormalConfig", "SUPPORT");
+			supportInterfaceConfig = new GCodePathConfig("supportInterfaceConfig", "SUPPORT-INTERFACE");
 
 			for (int layerIndex = 0; layerIndex < totalLayers; layerIndex++)
 			{

--- a/MatterSliceLib/fffProcessor.cs
+++ b/MatterSliceLib/fffProcessor.cs
@@ -125,7 +125,8 @@ namespace MatterHackers.MatterSlice
 
 			Stopwatch timeKeeperTotal = new Stopwatch();
 			timeKeeperTotal.Start();
-			preSetup(config.ExtrusionWidth_um);
+
+			gcodeExport.SetLayerChangeCode(config.LayerChangeCode);
 
 			SliceModels(slicingData);
 
@@ -160,7 +161,6 @@ namespace MatterHackers.MatterSlice
 
 		public bool LoadStlFile(string input_filename)
 		{
-			preSetup(config.ExtrusionWidth_um);
 			timeKeeper.Restart();
 			if (!SimpleMeshCollection.LoadModelFromFile(simpleMeshCollection, input_filename, config.ModelMatrix))
 			{
@@ -183,26 +183,6 @@ namespace MatterHackers.MatterSlice
 			gcodeExport.Finalize(maxObjectHeight, config.TravelSpeed, config.EndCode);
 
 			gcodeExport.Close();
-		}
-
-		private void preSetup(long extrusionWidth_um)
-		{
-			skirtConfig.SetData(config.InsidePerimetersSpeed, extrusionWidth_um);
-			inset0Config.SetData(config.OutsidePerimeterSpeed, config.OutsideExtrusionWidth_um);
-			insetXConfig.SetData(config.InsidePerimetersSpeed, extrusionWidth_um);
-
-			fillConfig.SetData(config.InfillSpeed, extrusionWidth_um);
-			topFillConfig.SetData(config.TopInfillSpeed, extrusionWidth_um);
-			firstTopFillConfig.SetData(config.BridgeSpeed, extrusionWidth_um);
-			bottomFillConfig.SetData(config.BottomInfillSpeed, extrusionWidth_um);
-			airGappedBottomConfig.SetData(config.AirGapSpeed, extrusionWidth_um);
-			airGappedBottomInsetConfig.SetData(config.AirGapSpeed, extrusionWidth_um);
-			bridgeConfig.SetData(config.BridgeSpeed, extrusionWidth_um);
-
-			supportNormalConfig.SetData(config.SupportMaterialSpeed, extrusionWidth_um);
-			supportInterfaceConfig.SetData(config.SupportMaterialSpeed, extrusionWidth_um);
-
-			gcodeExport.SetLayerChangeCode(config.LayerChangeCode);
 		}
 
 		private void SliceModels(LayerDataStorage slicingData)


### PR DESCRIPTION
- Set GCodePathConfig GCode comments with constructor param
- Set GCodePathConfig closedLoop indicator with constructor param
- Remove preSetup function which seemed to have no previous effect, aside from setting LayerChangeCode
