### PR TITLE
Infill honoring xy distance correctly

### DIFF
--- a/MatterSliceLib/ConfigSettings.cs
+++ b/MatterSliceLib/ConfigSettings.cs
@@ -296,9 +296,6 @@ namespace MatterHackers.MatterSlice
 		[SettingDescription("The number of layers to skip in z. The gap between the support and the model.")]
 		public int SupportNumberOfLayersToSkipInZ { get; set; }
 
-		[SettingDescription("The percent of support to generate.")]
-		public double SupportPercent { get; set; }
-
 		//Support material
 		public ConfigConstants.SUPPORT_TYPE SupportType { get; set; }
 
@@ -613,7 +610,6 @@ namespace MatterHackers.MatterSlice
 			RaftExtraDistanceAroundPart = 5;
 
 			SupportType = ConfigConstants.SUPPORT_TYPE.GRID;
-			SupportPercent = 50;
 			GenerateSupportPerimeter = true;
 			RaftExtruder = -1;
 			SupportLineSpacing = ExtrusionWidth * 5;

--- a/MatterSliceLib/GCodePathConfig.cs
+++ b/MatterSliceLib/GCodePathConfig.cs
@@ -38,7 +38,7 @@ namespace MatterHackers.MatterSlice
 
 		public string GCodeComment { get; set; }
 
-		public long LineWidthUM { get; set; }
+		public long LineWidth_um { get; set; }
 
 		public string Name { get; set; }
 
@@ -50,11 +50,11 @@ namespace MatterHackers.MatterSlice
 		/// Set the data for a path config. This is used to define how different parts (infill, perimeters) are written to gcode.
 		/// </summary>
 		/// <param name="speed"></param>
-		/// <param name="lineWidthUM"></param>
-		public void SetData(double speed, long lineWidthUM)
+		/// <param name="lineWidth_um"></param>
+		public void SetData(double speed, long lineWidth_um)
 		{
 			this.Speed = speed;
-			this.LineWidthUM = lineWidthUM;
+			this.LineWidth_um = lineWidth_um;
 		}
 	}
 }

--- a/MatterSliceLib/LayerDataStorage.cs
+++ b/MatterSliceLib/LayerDataStorage.cs
@@ -82,6 +82,7 @@ namespace MatterHackers.MatterSlice
 
 			for (int layerIndex = 0; layerIndex < totalLayers; layerIndex++)
 			{
+				// get rid of thin sections by reducing than expanding back the outlines
 				this.WipeShield[layerIndex] = this.WipeShield[layerIndex].Offset(-1000).Offset(1000);
 			}
 
@@ -191,7 +192,7 @@ namespace MatterHackers.MatterSlice
 			{
 				CheckNoExtruderPrimed(config);
 
-				long insetPerLoop = fillConfig.LineWidthUM;
+				long insetPerLoop = fillConfig.LineWidth_um;
 				int maxPrimingLoops = MaxPrimingLoops(config);
 
 				Polygons outlineForExtruder = this.WipeTower;
@@ -372,7 +373,7 @@ namespace MatterHackers.MatterSlice
 
 			// If we changed extruder, print the wipe/prime tower for this nozzle;
 			var fillPolygons = new Polygons();
-			GenerateWipeTowerInfill(primesThisLayer, this.WipeTower, fillPolygons, fillConfig.LineWidthUM, config);
+			GenerateWipeTowerInfill(primesThisLayer, this.WipeTower, fillPolygons, fillConfig.LineWidth_um, config);
 
 			if (fillPolygons.Count > 0)
 			{

--- a/MatterSliceLib/LayerGCodePlanner.cs
+++ b/MatterSliceLib/LayerGCodePlanner.cs
@@ -142,7 +142,7 @@ namespace MatterHackers.MatterSlice
 
 		private bool PathCanAdjustSpeed(GCodePath path)
 		{
-			return path.Config.LineWidthUM > 0 && path.Config.GCodeComment != "BRIDGE";
+			return path.Config.LineWidth_um > 0 && path.Config.GCodeComment != "BRIDGE";
 		}
 
 		public void CorrectLayerTimeConsideringMinimumLayerTime()
@@ -458,7 +458,7 @@ namespace MatterHackers.MatterSlice
 				{
 					double timeOfMove = 0;
 
-					if (path.Config.LineWidthUM == 0)
+					if (path.Config.LineWidth_um == 0)
 					{
 						var lengthToStart = (gcodeExport.GetPosition() - path.Polygon[0]).Length();
 						var lengthOfMove = lengthToStart + path.Polygon.PolygonLength();
@@ -479,12 +479,12 @@ namespace MatterHackers.MatterSlice
 
 				if (path.Polygon.Count == 1
 					&& path.Config != travelConfig
-					&& (gcodeExport.GetPositionXY() - path.Polygon[0]).ShorterThen(path.Config.LineWidthUM * 2))
+					&& (gcodeExport.GetPositionXY() - path.Polygon[0]).ShorterThen(path.Config.LineWidth_um * 2))
 				{
 					//Check for lots of small moves and combine them into one large line
 					IntPoint nextPosition = path.Polygon[0];
 					int i = pathIndex + 1;
-					while (i < paths.Count && paths[i].Polygon.Count == 1 && (nextPosition - paths[i].Polygon[0]).ShorterThen(path.Config.LineWidthUM * 2))
+					while (i < paths.Count && paths[i].Polygon.Count == 1 && (nextPosition - paths[i].Polygon[0]).ShorterThen(path.Config.LineWidth_um * 2))
 					{
 						nextPosition = paths[i].Polygon[0];
 						i++;
@@ -504,13 +504,13 @@ namespace MatterHackers.MatterSlice
 							long newLen = (gcodeExport.GetPosition() - newPoint).Length();
 							if (newLen > 0)
 							{
-								gcodeExport.WriteMove(newPoint, path.Speed, (int)(path.Config.LineWidthUM * oldLen / newLen));
+								gcodeExport.WriteMove(newPoint, path.Speed, (int)(path.Config.LineWidth_um * oldLen / newLen));
 							}
 
 							nextPosition = paths[x + 1].Polygon[0];
 						}
 
-						long lineWidth_um = path.Config.LineWidthUM;
+						long lineWidth_um = path.Config.LineWidth_um;
 						if (paths[i - 1].Polygon[0].Width != 0)
 						{
 							lineWidth_um = paths[i - 1].Polygon[0].Width;
@@ -557,7 +557,7 @@ namespace MatterHackers.MatterSlice
 						currentPosition = nextPosition;
 						IntPoint nextExtrusion = path.Polygon[i];
 						nextExtrusion.Z = (int)(z + layerThickness_um * length / totalLength + .5);
-						gcodeExport.WriteMove(nextExtrusion, path.Speed, path.Config.LineWidthUM);
+						gcodeExport.WriteMove(nextExtrusion, path.Speed, path.Config.LineWidth_um);
 					}
 				}
 				else
@@ -575,7 +575,7 @@ namespace MatterHackers.MatterSlice
 					// This is test code to remove double drawn small perimeter lines.
 					if (trimmed)
 					{
-						long targetDistance = (long)(path.Config.LineWidthUM * (1 - perimeterStartEndOverlapRatio));
+						long targetDistance = (long)(path.Config.LineWidth_um * (1 - perimeterStartEndOverlapRatio));
 						path = TrimGCodePathEnd(path, targetDistance);
 						// update the point count after trimming
 						pointCount = path.Polygon.Count;
@@ -583,7 +583,7 @@ namespace MatterHackers.MatterSlice
 
 					for (int i = 0; i < pointCount; i++)
 					{
-						long lineWidth_um = path.Config.LineWidthUM;
+						long lineWidth_um = path.Config.LineWidth_um;
 						if (path.Polygon[i].Width != 0)
 						{
 							lineWidth_um = path.Polygon[i].Width;

--- a/MatterSliceLib/MultiExtruders.cs
+++ b/MatterSliceLib/MultiExtruders.cs
@@ -90,7 +90,6 @@ namespace MatterHackers.MatterSlice
 			int parseIndex = 0;
 			int totalLayers = loadedMeshes[0].Layers.Count;
 			List<int> meshesToProcess = new List<int>();
-			bool foundSupport = false;
 			int numberOfOpens = 0;
 			while (parseIndex < booleanOperations.Length)
 			{
@@ -126,7 +125,6 @@ namespace MatterHackers.MatterSlice
 
 					case 'S':
 						parseIndex++;
-						foundSupport = true;
 						break;
 
 					case 'W':
@@ -159,13 +157,6 @@ namespace MatterHackers.MatterSlice
 
 						for (int layerIndex = 0; layerIndex < totalLayers; layerIndex++)
 						{
-							if(foundSupport)
-							{
-								// grow the support outlines of the incoming union
-								loadedMeshes[removeExtruderIndex].Layers[layerIndex].AllOutlines 
-									= Clipper.CleanPolygons(loadedMeshes[removeExtruderIndex].Layers[layerIndex].AllOutlines.Offset(1000), cleanDistance_um);
-							}
-
 							SliceLayer keepLayer = loadedMeshes[keepExtruderIndex].Layers[layerIndex];
 							SliceLayer removeLayer = loadedMeshes[removeExtruderIndex].Layers[layerIndex];
 							DoLayerBooleans(keepLayer, removeLayer, typeToDo);

--- a/MatterSliceLib/PathOrderOptimizer.cs
+++ b/MatterSliceLib/PathOrderOptimizer.cs
@@ -79,7 +79,7 @@ namespace MatterHackers.MatterSlice
 						&& config.DoSeamHiding
 						&& !config.Spiralize)
 					{
-						bestPointIndex = currentPolygon.FindGreatestTurnIndex(startPosition, layerIndex, config.LineWidthUM);
+						bestPointIndex = currentPolygon.FindGreatestTurnIndex(startPosition, layerIndex, config.LineWidth_um);
 					}
 					else
 					{

--- a/MatterSliceLib/fffProcessor.cs
+++ b/MatterSliceLib/fffProcessor.cs
@@ -281,7 +281,7 @@ namespace MatterHackers.MatterSlice
 				&& !config.ContinuousSpiralOuterPerimeter)
 			{
 				timeKeeper.Restart();
-				slicingData.Support = new NewSupport(config, slicingData.Extruders, supportOutlines, 0);
+				slicingData.Support = new NewSupport(config, slicingData.Extruders, supportOutlines);
 				LogOutput.Log("Generating supports in {0:0.0}s \n".FormatWith(timeKeeper.Elapsed.TotalSeconds));
 			}
 
@@ -817,7 +817,7 @@ namespace MatterHackers.MatterSlice
 
 			if (perimeterToCheckForMerge.Count > 2)
 			{
-				pathHadOverlaps = perimeterToCheckForMerge.MergePerimeterOverlaps(config.LineWidthUM, out pathsWithOverlapsRemoved, pathIsClosed)
+				pathHadOverlaps = perimeterToCheckForMerge.MergePerimeterOverlaps(config.LineWidth_um, out pathsWithOverlapsRemoved, pathIsClosed)
 					&& pathsWithOverlapsRemoved.Count > 0;
 			}
 
@@ -1457,7 +1457,7 @@ namespace MatterHackers.MatterSlice
 				&& layerIndex > 0
 				&& !config.ContinuousSpiralOuterPerimeter)
 			{
-				Polygons supportOutlines = slicingData.Support.GetRequiredSupportAreas(layerIndex).Offset(fillConfig.LineWidthUM / 2);
+				Polygons supportOutlines = slicingData.Support.GetRequiredSupportAreas(layerIndex).Offset(fillConfig.LineWidth_um / 2);
 
 				if (supportWriteType == SupportWriteType.UnsupportedAreas)
 				{
@@ -1508,7 +1508,7 @@ namespace MatterHackers.MatterSlice
 		private void GetSegmentsConsideringSupport(Polygons polygonsToWrite, Polygons supportOutlines, Polygons polysToWriteAtNormalHeight, Polygons polysToWriteAtAirGapHeight, bool forAirGap, bool closedLoop)
 		{
 			// make an expanded area to constrain our segments to
-			Polygons maxSupportOutlines = supportOutlines.Offset(fillConfig.LineWidthUM * 2 + config.SupportXYDistance_um);
+			Polygons maxSupportOutlines = supportOutlines.Offset(fillConfig.LineWidth_um * 2 + config.SupportXYDistance_um);
 
 			Polygons polygonsToWriteAsLines = PolygonsHelper.ConvertToLines(polygonsToWrite, closedLoop);
 

--- a/Tests/MatterSlice.Tests/MatterSlice/GCodePlannerTests.cs
+++ b/Tests/MatterSlice.Tests/MatterSlice/GCodePlannerTests.cs
@@ -48,7 +48,7 @@ namespace MatterHackers.MatterSlice.Tests
 
 				GCodePath controlPath = Newtonsoft.Json.JsonConvert.DeserializeObject<GCodePath>("{\"config\":{\"closedLoop\":true,\"lineWidth_um\":500,\"gcodeComment\":\"WALL-OUTER\",\"speed\":18.9,\"spiralize\":false,\"doSeamHiding\":true,\"Name\":\"inset0Config\"},\"points\":[{\"x\":105366,\"y\":108976,\"z\":300},{\"x\":105743,\"y\":109188,\"z\":300},{\"x\":106352,\"y\":109582,\"z\":300},{\"x\":106606,\"y\":109674,\"z\":300},{\"x\":107513,\"y\":110120,\"z\":300},{\"x\":107766,\"y\":110836,\"z\":300},{\"x\":107804,\"y\":110986,\"z\":300},{\"x\":107806,\"y\":111124,\"z\":300},{\"x\":106720,\"y\":116034,\"z\":300},{\"x\":106669,\"y\":116205,\"z\":300},{\"x\":106345,\"y\":116505,\"z\":300},{\"x\":103152,\"y\":117619,\"z\":300},{\"x\":102975,\"y\":117661,\"z\":300},{\"x\":102749,\"y\":117546,\"z\":300},{\"x\":101132,\"y\":116186,\"z\":300},{\"x\":100997,\"y\":115990,\"z\":300},{\"x\":100845,\"y\":115704,\"z\":300},{\"x\":100673,\"y\":114777,\"z\":300},{\"x\":100959,\"y\":109833,\"z\":300},{\"x\":101785,\"y\":109149,\"z\":300},{\"x\":101836,\"y\":109129,\"z\":300},{\"x\":101976,\"y\":109137,\"z\":300},{\"x\":102415,\"y\":109277,\"z\":300},{\"x\":102712,\"y\":108910,\"z\":300},{\"x\":103239,\"y\":108477,\"z\":300},{\"x\":103355,\"y\":108453,\"z\":300},{\"x\":103710,\"y\":108924,\"z\":300},{\"x\":104116,\"y\":108883,\"z\":300},{\"x\":104330,\"y\":108371,\"z\":300},{\"x\":104867,\"y\":108245,\"z\":300},{\"x\":104888,\"y\":108273,\"z\":300},{\"x\":104927,\"y\":108647,\"z\":300}]}");
 
-				long targetDistance = (long)(inPath.Config.LineWidthUM);
+				long targetDistance = (long)(inPath.Config.LineWidth_um);
 				GCodePath testPath = LayerGCodePlanner.TrimGCodePathEnd(inPath, targetDistance);
 
 				Assert.IsTrue(controlPath.Polygon.Count == testPath.Polygon.Count);
@@ -500,7 +500,7 @@ namespace MatterHackers.MatterSlice.Tests
 			Polygons pathsWithOverlapsRemoved;
 			bool pathIsClosed = false;
 
-			bool pathHadOverlaps = path.Polygon.MergePerimeterOverlaps(path.Config.LineWidthUM, out pathsWithOverlapsRemoved, pathIsClosed)
+			bool pathHadOverlaps = path.Polygon.MergePerimeterOverlaps(path.Config.LineWidth_um, out pathsWithOverlapsRemoved, pathIsClosed)
 				&& pathsWithOverlapsRemoved.Count > 0;
 
 			Assert.IsFalse(pathHadOverlaps);

--- a/Tests/MatterSlice.Tests/MatterSlice/SupportTests.cs
+++ b/Tests/MatterSlice.Tests/MatterSlice/SupportTests.cs
@@ -88,7 +88,7 @@ namespace MatterHackers.MatterSlice.Tests
 					supportOutlines.Add(new Polygons());
 				}
 
-				var outputs = CreateLayerData(config, partOutlines, supportOutlines, 1000);
+				var outputs = CreateLayerData(config, partOutlines, supportOutlines);
 				ExtruderLayers layerData = outputs.Item1;
 				NewSupport supportGenerator = outputs.Item2;
 
@@ -107,7 +107,7 @@ namespace MatterHackers.MatterSlice.Tests
 				}
 
 				{
-					Polygons expectedSupportOutlines = topCubeOutlineResults.Offset(1000);
+					Polygons expectedSupportOutlines = topCubeOutlineResults.Offset(200);
 					// check the air gapped bottom support outlines (only 5)
 					{
 						List<int> polygonsCounts = new List<int> { 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, };
@@ -161,11 +161,12 @@ namespace MatterHackers.MatterSlice.Tests
 					supportOutlines.Add(new Polygons());
 				}
 
-				var outputs = CreateLayerData(config, partOutlines, supportOutlines, 0);
+				var outputs = CreateLayerData(config, partOutlines, supportOutlines);
 				ExtruderLayers layerData = outputs.Item1;
 				NewSupport supportGenerator = outputs.Item2;
 
 				Polygons cubeOutlineResults = CLPolygonsExtensions.CreateFromString("x:200, y:200,x:9800, y:200,x:9800, y:9800,x:200, y:9800,|");
+				Polygons cubeInfillResults = CLPolygonsExtensions.CreateFromString("x:0, y:0,x:10000, y:0,x:10000, y:10000,x:0, y:10000,|");
 
 				// check the all part outlines
 				{
@@ -179,7 +180,7 @@ namespace MatterHackers.MatterSlice.Tests
 				{
 					List<int> polygonsCounts = new List<int> { 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, };
 					List<int> polygon0Counts = new List<int> { 4, 4, 4, 4, 4, 0, 0, 0, 0, 0, };
-					List<Polygons> poly0Paths = new List<Polygons>() { cubeOutlineResults, cubeOutlineResults, cubeOutlineResults, cubeOutlineResults, cubeOutlineResults, null, null, null, null, null };
+					List<Polygons> poly0Paths = new List<Polygons>() { cubeInfillResults, cubeInfillResults, cubeInfillResults, cubeInfillResults, cubeInfillResults, null, null, null, null, null };
 					CheckLayers(supportGenerator.SparseSupportOutlines, polygonsCounts, polygon0Counts, poly0Paths);
 				}
 
@@ -239,7 +240,7 @@ namespace MatterHackers.MatterSlice.Tests
 					partOutlines.Add(cubeOutline);
 				}
 
-				var outputs = CreateLayerData(config, partOutlines, supportOutlines, 1000);
+				var outputs = CreateLayerData(config, partOutlines, supportOutlines);
 				ExtruderLayers layerData = outputs.Item1;
 				NewSupport supportGenerator = outputs.Item2;
 
@@ -282,8 +283,7 @@ namespace MatterHackers.MatterSlice.Tests
 
 		private static (ExtruderLayers, NewSupport) CreateLayerData(ConfigSettings config,
 			List<Polygons> totalLayerOutlines, 
-			List<Polygons> supportOutlines,
-			long grabDistance_um)
+			List<Polygons> supportOutlines)
 		{
 			int numLayers = totalLayerOutlines.Count;
 			var layerData = new ExtruderLayers();
@@ -302,11 +302,11 @@ namespace MatterHackers.MatterSlice.Tests
 					supportData.Layers.Add(supportLayer);
 				}
 			}
-			var newSupport = new NewSupport(config, new List<ExtruderLayers>() { layerData }, supportData, grabDistance_um);
+			var newSupport = new NewSupport(config, new List<ExtruderLayers>() { layerData }, supportData);
 			return (layerData, newSupport);
 		}
 
-		private void CheckLayers(List<Polygons> polygonsToValidate, List<int> polygonsCounts, List<int> polygon0Counts, List<Polygons> poly0Paths)
+		private void CheckLayers(List<Polygons> polygonsToValidate, List<int> polygonsCounts, List<int> polygon0Counts, List<Polygons> controlPaths)
 		{
 			for (int i = 0; i < polygonsToValidate.Count; i++)
 			{
@@ -314,7 +314,7 @@ namespace MatterHackers.MatterSlice.Tests
 				if (polygonsToValidate[i].Count > 0)
 				{
 					Assert.IsTrue(polygonsToValidate[i][0].Count == polygon0Counts[i]);
-					Assert.IsTrue(polygonsToValidate[i][0].DescribesSameShape(poly0Paths[i][0]));
+					Assert.IsTrue(polygonsToValidate[i][0].DescribesSameShape(controlPaths[i][0]));
 				}
 			}
 		}


### PR DESCRIPTION
took out unused support %

issue: MatterHackers/MCCentral#5229
Support is 1/2 nozzle diameter into the shape it is against (when xy distance set to 0)