### PR TITLE
Use dedicated config for fill thin gap polygons

### DIFF
--- a/MatterSliceLib/GCodePathConfig.cs
+++ b/MatterSliceLib/GCodePathConfig.cs
@@ -56,5 +56,17 @@ namespace MatterHackers.MatterSlice
 			this.Speed = speed;
 			this.LineWidth_um = lineWidth_um;
 		}
+
+		public GCodePathConfig Clone(string newConfigName, string newGCodeComment)
+		{
+			return new GCodePathConfig(newConfigName, newGCodeComment)
+			{
+				ClosedLoop = this.ClosedLoop,
+				DoSeamHiding = this.DoSeamHiding,
+				LineWidth_um = this.LineWidth_um,
+				Speed = this.Speed,
+				Spiralize = this.Spiralize
+			};
+		}
 	}
 }


### PR DESCRIPTION
Possible fix for MatterHackers/MCCentral#5178

- Mark as ClosedLoop = false
- Issue MatterHackers/MCCentral#5178
Slicer extrudes outside of part bounds