### PR TITLE
Don't go to the wipe tower if we are not going to print it

### DIFF
--- a/MatterSliceLib/LayerDataStorage.cs
+++ b/MatterSliceLib/LayerDataStorage.cs
@@ -226,7 +226,10 @@ namespace MatterHackers.MatterSlice
 
 				// set the path planner to avoid islands
 				layerGcodePlanner.PathFinder = pathFinder;
-				layerGcodePlanner.QueueTravel(WipeCenter_um);
+				if (this.NeedToPrintWipeTower(layerIndex, config))
+				{
+					layerGcodePlanner.QueueTravel(WipeCenter_um);
+				}
 
 				// turn off the planner for the wipe tower
 				layerGcodePlanner.PathFinder = null;


### PR DESCRIPTION
issue: MatterHackers/MCCentral#5387
Move to origin at the end of first layer on Dual Extrusion print