### PR TITLE
.NET 6 Upgrade (Change build output path for AppVeyor)

### DIFF
--- a/Tests/MatterSlice.Tests/MatterSlice.Tests.csproj
+++ b/Tests/MatterSlice.Tests/MatterSlice.Tests.csproj
@@ -7,6 +7,10 @@
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\</SolutionDir>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+
+	<!-- AppVeyor builder wants the old paths. -->
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />


### PR DESCRIPTION
Continuation of https://github.com/MatterHackers/MatterSlice/pull/612.

Changed output build path for tests in AppVeyor.